### PR TITLE
Add piecewise hazard support, AHR definition, and NPH robustness stra…

### DIFF
--- a/group_sequential_design/SKILL.md
+++ b/group_sequential_design/SKILL.md
@@ -66,7 +66,11 @@ This gives the user a visual progress indicator (spinner → checkmark) througho
    **Multiplicity diagram:** The node labels must show the **actual initial alpha** (e.g., 0.005), not the fraction of total alpha. Pass the raw alpha values directly as `hypotheses` — `graphicalMCP` displays whatever values you pass. Use `hyp_names` for the hypothesis name + endpoint (e.g., `"H1\nPFS-Ext"`) and `precision = 4` in `plot()`.
 
 7. **Check IA timing vs enrollment** — Compare each interim analysis calendar time against the enrollment duration. If ANY interim analysis occurs before enrollment completes, **warn the user** and present options to fix it (see "IA Timing vs Enrollment Check" section below). Do NOT proceed until the user confirms the design or adjusts it.
-7b. **NPH Evaluation** *(only if user specified NPH in Q7b)* — With the PH design complete (events, boundaries, enrollment from steps 1–7), evaluate it under the NPH assumptions. See "NPH Evaluation Workflow" section below. Present the NPH evaluation table to the user. If power under NPH is unacceptable, discuss options (increase events, adjust alpha split, accept lower power) before proceeding.
+7b. **NPH Evaluation** *(only if user specified NPH in Q7b)* — With the PH design complete (events, boundaries, enrollment from steps 1–7), evaluate it under the NPH assumptions. See "NPH Evaluation Workflow" section below. Present the NPH evaluation table to the user. If power under NPH is unacceptable, discuss options before proceeding:
+   - **Add looks for NPH robustness**: If there is a large gap between analyses AND the endpoint's AHR improves over time, suggest adding the endpoint to an additional analysis. This gives the endpoint a second chance at a later timepoint with better AHR. See `reference.md` → "Adding Looks for NPH Robustness" for the full strategy. When evaluating timing options for the additional analysis, always compute and compare the NPH endpoint's power at each option — the timing should be driven by NPH power, not just the triggering endpoint's IF.
+   - **Alpha reallocation**: Shift alpha from an over-powered endpoint to the NPH-affected endpoint
+   - **Increase N**: More events improve AHR over time (modest effect)
+   - **Accept lower NPH power**: If NPH is a sensitivity analysis, not the primary design basis
 8. **Verify via simulation** — Run `lrstat` simulation. Save verification script and log in the subfolder. If verification FAILS, investigate and fix the design before proceeding. *(If NPH was specified, run verification under BOTH PH and NPH assumptions.)*
 9. **Generate Word report via Python** — Only after verification passes. **Before writing `gsd_report.py`, read `reference.md` → "Report Sections", "Boundary Table Format", "IA/FA Plan Table Format", and "Sample Size and Power Summary"** to get the exact section order, table columns, and content requirements. Then write the script to match that spec exactly. The report has 6 sections: (1) Design Assumptions, (2) IA/FA Analysis Plan, (3) Multiplicity Strategy, (4) Efficacy/Futility Boundaries, (5) Sample Size and Power Summary, (6) Design Assessment.
 
@@ -208,6 +212,8 @@ Collect design parameters by asking **ONE question at a time**. Wait for the use
    - D) Other — specify a ratio
 
 6. "On the standard treatment, how long do patients typically survive (or stay progression-free) before half of them have an event? This is the 'median' in months."
+
+   **Piecewise control hazards:** If the user specifies a piecewise control hazard (e.g., "log(2)/4 for the first 3 months, then log(2)/8 thereafter"), accept it. This is common when early event rates differ from later rates (e.g., high early progression risk that decreases). Store as `lambdaC = c(log(2)/4, log(2)/8)` with breakpoint `S = 3`. Use `calc_expected_events_pw()` from `examples.md` for event calculations and `gsSurv(lambdaC=..., S=...)` for boundary computation. For required events, use Schoenfeld formula (not nSurv) when the HR is constant — see `reference.md` → "Schoenfeld vs nSurv with piecewise control hazards".
 
    *(If multi-population)* Ask per population × endpoint. Offer shortcut: "If medians are the same across populations, just give one number per endpoint."
    - Control median PFS in subgroup? (e.g., 8 months)

--- a/group_sequential_design/examples.md
+++ b/group_sequential_design/examples.md
@@ -1001,6 +1001,94 @@ find_event_time <- function(target_events, lambdaC, hr, eta, gamma_vec, R_vec, r
 
 ---
 
+## Analytical Expected Events Calculator — Piecewise Hazards
+
+Extension of `calc_expected_events()` for piecewise exponential control hazard with constant HR. Uses closed-form integration within each hazard piece for speed.
+
+```r
+# Expected events at calendar time T_cal with PIECEWISE control hazard
+# lambdaC_pw: vector of control hazard rates (e.g., c(log(2)/4, log(2)/8))
+# S: vector of breakpoints (e.g., 3 for change at 3 months)
+# hr: constant hazard ratio (PH design)
+# eta: constant dropout hazard
+calc_expected_events_pw <- function(T_cal, lambdaC_pw, S, hr, eta,
+                                    gamma_vec, R_vec, ratio_val) {
+  breaks <- c(0, S)
+  n_pieces <- length(lambdaC_pw)
+
+  # Event probability for a patient with follow-up f on one arm
+  event_prob_arm <- function(f, lambdas) {
+    if (f <= 0) return(0)
+    prob <- 0
+    cum_haz <- 0
+    for (j in seq_along(lambdas)) {
+      t_start <- if (j == 1) 0 else breaks[j]
+      t_end <- if (j < n_pieces) breaks[j + 1] else Inf
+      piece_end <- min(f, t_end)
+      if (t_start >= piece_end) {
+        cum_haz <- cum_haz + lambdas[j] * max(0, min(f, t_end) - t_start)
+        next
+      }
+      lam <- lambdas[j]
+      d <- piece_end - t_start
+      total_rate <- lam + eta
+      if (total_rate > 0) {
+        prob <- prob + lam / total_rate *
+          exp(-cum_haz - eta * t_start) *
+          (1 - exp(-total_rate * d))
+      }
+      cum_haz <- cum_haz + lam * d
+    }
+    prob
+  }
+
+  lambdas_exp <- lambdaC_pw * hr
+  enroll_starts <- c(0, cumsum(R_vec[-length(R_vec)]))
+  enroll_ends <- cumsum(R_vec)
+
+  total_events <- 0
+  n_pts <- 100  # integration points per enrollment period
+  for (i in seq_along(gamma_vec)) {
+    s_start <- enroll_starts[i]
+    s_end <- min(enroll_ends[i], T_cal)
+    if (s_start >= T_cal) next
+    rate <- gamma_vec[i]
+    dt <- (s_end - s_start) / n_pts
+    for (k in 1:n_pts) {
+      et <- s_start + (k - 0.5) * dt
+      fup <- T_cal - et
+      ep_ctrl <- event_prob_arm(fup, lambdaC_pw)
+      ep_exp <- event_prob_arm(fup, lambdas_exp)
+      total_events <- total_events +
+        rate * (1 / (1 + ratio_val)) * ep_ctrl * dt +
+        rate * (ratio_val / (1 + ratio_val)) * ep_exp * dt
+    }
+  }
+  total_events
+}
+
+# Binary search wrapper
+find_event_time_pw <- function(target_events, lambdaC_pw, S, hr, eta,
+                               gamma_vec, R_vec, ratio_val) {
+  lo <- 1; hi <- sum(R_vec) + 120
+  for (i in 1:100) {
+    mid <- (lo + hi) / 2
+    d <- calc_expected_events_pw(mid, lambdaC_pw, S, hr, eta, gamma_vec, R_vec, ratio_val)
+    if (d < target_events) lo <- mid else hi <- mid
+    if (abs(hi - lo) < 0.01) break
+  }
+  mid
+}
+```
+
+**When to use**: When the control hazard is piecewise exponential (e.g., high early hazard that drops after 3 months) and you need to compute events at an arbitrary calendar time. Common in solid tumors where early progression risk differs from later risk.
+
+**Verified**: Timing estimates match `lrsim()` simulation within 0.5 months (verified with piecewise PFS hazard log(2)/4 for 0–3 mo, log(2)/8 after 3 mo, N=675, 10,000 simulations).
+
+**Note**: For required event calculation with piecewise control and constant HR, use the Schoenfeld formula — not `nSurv()` with piecewise `lambdaC`, which can overestimate events. See `reference.md` → "Schoenfeld vs nSurv with piecewise control hazards".
+
+---
+
 ## Transition Matrix Validation
 
 Validates that the transition matrix does not route alpha from any hypothesis back to a hypothesis that must already be rejected for it to be testable (Rule 3). **Must be called in every step-down design script** immediately after defining the transition matrix, before computing any boundaries.

--- a/group_sequential_design/reference.md
+++ b/group_sequential_design/reference.md
@@ -608,6 +608,13 @@ For 14+ hypotheses, place labels at 30% or 70% along arrows instead of 50% midpo
 ### gsSurv() vs gsDesign(): when to use which
 `gsSurv()` computes events/sample size from survival assumptions. `gsDesign()` with `n.I` when events are already known.
 
+### Schoenfeld vs nSurv with piecewise control hazards
+When the control hazard is piecewise (e.g., `lambdaC = c(log(2)/4, log(2)/8), S = 3`) but the HR is constant (PH design), `nSurv()` can massively overestimate required events — e.g., 782 vs Schoenfeld's 477 for alpha=0.001, HR=0.67. The Lachin-Foulkes formula inside `nSurv()` interacts poorly with piecewise hazard specifications, producing inflated event counts.
+
+**Why Schoenfeld is valid here:** With constant HR, the proportion of events from each arm is `1/(1+HR)` — invariant to the baseline hazard level. So the information per event is the same regardless of whether the control hazard is high (early period) or low (later period). The Schoenfeld approximation of D/4 variance per event holds.
+
+**Fix:** For piecewise control hazard with constant HR, use the Schoenfeld formula `events = 4 × (z_α + z_β)² / log(HR)²` for required events. Verify with simulation. Reserve nSurv/Lachin-Foulkes for scenarios where the HR or allocation ratio varies over time.
+
 ### Do NOT use nSurv()/gsSurv() to size multi-population designs
 `nSurv()` solves for enrollment duration to achieve target power, but it couples enrollment and events in ways that can oversize the design — especially for subpopulations where the effective enrollment rate is `prevalence × gamma`. The Lachin-Foulkes formula inside `nSurv()` may return substantially more events than the Schoenfeld approximation (e.g., 422 vs 324) depending on the follow-up/median ratio. **Fix**: For multi-population designs, compute required events analytically using the Schoenfeld formula `events = 4 × (z_α + z_β)² / log(HR)²`, then size enrollment to support those events. Use `gsDesign()` with pre-specified events for boundary computation.
 
@@ -815,6 +822,25 @@ When a user specifies non-proportional hazards (piecewise control hazard and/or 
    - Average HR at each analysis (the effective HR the log-rank test sees)
    - Power at each analysis using the PH boundaries
 
+### What is AHR (Average Hazard Ratio)?
+
+The AHR is the **effective HR that the log-rank test statistic reflects at a given analysis time** under non-proportional hazards. It is a weighted geometric mean of the piecewise HRs:
+
+```
+AHR(t) = exp( sum[ log(HR_j) × d_j(t) ] / D(t) )
+       = product( HR_j ^ (d_j(t) / D(t)) )
+```
+
+where `HR_j` is the hazard ratio in period j, `d_j(t)` is the expected events in period j by calendar time t, and `D(t)` is total expected events. Periods with more events get more weight.
+
+The AHR connects NPH assumptions to standard power formulas: `E[Z] ≈ -log(AHR) × sqrt(D/4)`. This means you can plug the AHR into Schoenfeld or `gs_power_npe()` as if it were a constant HR.
+
+**Key properties:**
+- Under PH (constant HR), AHR = HR at all times
+- Under delayed effect (HR=1 early, HR<1 later), AHR starts near 1 and decreases over time
+- High early control hazard amplifies the weight of the HR=1 period, pulling AHR toward 1
+- Computed in R via `gsDesign2::ahr(total_duration=t)` or `gsDesign2::expected_time(target_event=D)`
+
 ### Why this approach works
 
 The key insight: **boundaries and event counts from the PH design remain valid under NPH.** Alpha spending boundaries depend only on the information fraction (ratio of events at IA to events at FA) and the spending function — not on the underlying hazard model. If the trial targets 395 OS events at the IA and 478 at the FA, the same Z-boundaries and p-value thresholds apply regardless of whether events came from a constant or piecewise hazard distribution.
@@ -949,6 +975,40 @@ Verify against analyticals:
 - Simulated type I error (H0) within ±0.5 pp of alpha
 
 Include both PH and NPH results in the verification log.
+
+### Adding Looks for NPH Robustness
+
+When NPH evaluation reveals low power for an endpoint (e.g., PFS power drops from 90% to 54% due to a delayed treatment effect), **adding an additional analysis for that endpoint** can substantially improve NPH robustness. This is distinct from the traditional reason for adding interims (early stopping) — here the goal is to give the endpoint a second chance at a later timepoint where the AHR has improved.
+
+**Why it works:** Under NPH with delayed effect (HR=1 early, HR=0.65 later), the AHR improves over time as more events accumulate in the post-delay period. A second look at a later timepoint sees a better AHR and has more events, both of which increase power. With OBF-like spending, most alpha is reserved for the later look, providing a meaningful shot at rejection.
+
+**Example:** PFS tested only at IA1 (30 mo) → 54% NPH power. Add PFS testing at IA2 (40 mo, OS-triggered) → 72% NPH power (+18 pp). The second look adds ~80 PFS events and the AHR improves from 0.747 to 0.732.
+
+**When to suggest this:**
+- NPH power drops > 10 pp from PH power
+- There is a large gap between existing analyses (e.g., 20 months) that could accommodate an additional analysis
+- The endpoint's AHR trajectory shows meaningful improvement over the gap period (check via `gsDesign2::ahr()` at multiple timepoints)
+
+**Implementation:**
+1. Add the endpoint to an existing or new analysis (e.g., test PFS at the OS-triggered IA2)
+2. The endpoint now has 2+ looks and needs a spending function (sfLDOF is a good default — saves most alpha for the later look)
+3. The additional analysis's timing is driven by the triggering endpoint (e.g., OS events), not the NPH endpoint
+4. **Evaluate NPH power at each candidate timing** to ensure the second look is meaningful — PFS events at IA2 and PFS AHR at IA2 are both derived quantities that depend on the IA2 timing
+5. Check that PFS IF at IA1 relative to IA2 is not too high (>95%), which would leave very little alpha for IA2
+
+**Side benefits:**
+- Breaks up a large analysis gap (e.g., 20 months → two ~10-month segments)
+- PH power actually increases (second chance under favorable conditions too)
+- Additional decision point for the trial
+
+### Cross-Endpoint NPH Power as IA Timing Criterion
+
+When an analysis is added specifically for NPH robustness, the timing should be informed by the **NPH endpoint's power**, not just the triggering endpoint's information fraction. When presenting IA2 timing options to the user, always compute and compare the NPH endpoint's:
+- Events at each option
+- AHR at each option (via `gsDesign2::ahr()`)
+- NPH power at each option (via `gs_power_npe()`)
+
+This ensures the timing choice is driven by the actual goal (NPH robustness) rather than just even spacing of the triggering endpoint's analyses.
 
 ---
 


### PR DESCRIPTION
…tegy

- reference.md: Add "Schoenfeld vs nSurv with piecewise control hazards" guidance (Schoenfeld valid when HR is constant, nSurv overestimates)
- reference.md: Add "What is AHR?" section with formula and properties
- reference.md: Add "Adding Looks for NPH Robustness" design strategy (adding endpoint to extra analysis to improve NPH power)
- reference.md: Add "Cross-Endpoint NPH Power as IA Timing Criterion"
- examples.md: Add calc_expected_events_pw() for piecewise control hazards
- SKILL.md: Update Q6 for piecewise control hazard collection
- SKILL.md: Update step 7b NPH options to include adding looks