### PR TITLE
feat: update benchmark converter to auto-save evals and add group sequential design evaluation cases

### DIFF
--- a/github_issue_benchmark_converter/SKILL.md
+++ b/github_issue_benchmark_converter/SKILL.md
@@ -40,10 +40,11 @@ A skill to automatically extract benchmark data from a GitHub Issue and format i
    }
    ```
 
-4. **Output or Save the JSON**:
-   Provide the formatted JSON locally. If the user asked you to update their local `evals.json` file, safely append or insert the eval block. Otherwise, return the JSON clearly in the chat.
-
-### Best Practices & Rules
-- Do NOT hallucinate assertions. Extract exactly what is documented under the Rubric section.
-- If an assertion is vague (e.g., "it should look good"), proactively prompt the user to redefine it into an objectively measurable piece of criteria before outputting the final JSON.
+4. **Save the JSON to the Target Skill's Eval Folder**:
+   Do NOT simply output the JSON into the chat. You must save it directly into the target skill's benchmark directory.
+   - Identify the `skill_name` that was extracted.
+   - Target the directory: `./[skill_name]/evals/`. Create the `evals/` folder if it does not already exist.
+   - If an `evals.json` file already exists inside this folder, securely append the new eval object into the existing `"evals": []` array. Ensure the JSON syntax remains valid after appending.
+   - If `evals.json` does not exist, create a new file and write the full JSON payload.
+   - Once saved, inform the user that the evaluation case was successfully added to `<skill_name>/evals/evals.json`.
 - If files are mentioned by name but no path is given, extract just the filenames. If a URL to a file is given, include the URL.

--- a/group_sequential_design/evals/evals.json
+++ b/group_sequential_design/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "group_sequential_design",
+  "evals": [
+    {
+      "id": "github-issue-2",
+      "prompt": "Following SAP from NCT05638204, reproduce number using group sequential design.",
+      "expected_output": "An R script running a group sequential design analysis that perfectly reproduces the exact clinical trial numbers specified in the attached SAP document.",
+      "files": [
+        "https://cdn.clinicaltrials.gov/large-docs/04/NCT05638204/SAP_000.pdf"
+      ],
+      "assertions": [
+        "The script must use the gsDesign R package.",
+        "The script must accurately reproduce the trial design parameters and numbers documented in the SAP."
+      ]
+    },
+    {
+      "id": "github-issue-3",
+      "prompt": "following SAP https://cdn.clinicaltrials.gov/large-docs/22/NCT01471522/SAP_003.pdf reproduce number using gsDesign",
+      "expected_output": "An R script that executes a group sequential design analysis mirroring the methodology in the attached SAP, outputting the reproduced clinical trial design numbers.",
+      "files": [
+        "https://cdn.clinicaltrials.gov/large-docs/22/NCT01471522/SAP_003.pdf"
+      ],
+      "assertions": [
+        "The script must use the gsDesign R package.",
+        "The output must accurately reproduce the exact trial numbers calculated in the SAP methodology."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
dry run two issues to create an eval json file