### PR TITLE
Add CRAN / Posit PPM to sandbox network allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,12 +13,29 @@
       "Bash(Rscript:*)",
       "Bash(R:*)",
       "Bash(zip:*)",
-      "Bash(uvx:*)"
+      "Bash(uvx:*)",
+      "WebFetch(domain:cran.r-project.org)",
+      "WebFetch(domain:cloud.r-project.org)",
+      "WebFetch(domain:packagemanager.posit.co)",
+      "WebFetch(domain:bioconductor.org)"
     ],
     "deny": [
       "Bash(git reset --hard:*)",
       "Bash(gh repo delete:*)",
       "Bash(rm -rf:*)"
     ]
+  },
+  "sandbox": {
+    "network": {
+      "allowedDomains": [
+        "cran.r-project.org",
+        "*.r-project.org",
+        "cloud.r-project.org",
+        "packagemanager.posit.co",
+        "*.posit.co",
+        "bioconductor.org",
+        "*.bioconductor.org"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `sandbox.network.allowedDomains` to `.claude/settings.json` listing `cran.r-project.org`, `*.r-project.org`, `cloud.r-project.org`, `packagemanager.posit.co`, `*.posit.co`, `bioconductor.org`, `*.bioconductor.org`
- Add matching `WebFetch(domain:...)` permission rules so WebFetch against those hosts is auto-allowed

## Why
The `group-sequential-design` skill wants to install R packages (`gsDesign`, `gsDesign2`, `lrstat`, `graphicalMCP`). When Claude Code runs in a **local** sandbox (macOS seccomp / Linux), these hosts need to be on the sandbox network allowlist or `install.packages()` is blocked and the agent falls back to a Python reimplementation — which is slower, less faithful to the skill's canonical `gsDesign` workflow, and was the root cause of an Agent A stream-idle timeout during a recent benchmark run.

## Caveat — does NOT unblock the managed cloud sandbox
On the Anthropic-managed cloud environment (image `sandbox-ccr-default`, `CLAUDE_CODE_REMOTE=true`), the HTTPS MITM proxy's host allowlist is **baked into the image**, not driven from `settings.json`. Verified by:

```
$ curl -sI https://cran.r-project.org/ | head -1
HTTP/2 403
x-deny-reason: host_not_allowed
```

…which persists after this change is applied. To unblock CRAN on the cloud sandbox, the session must be configured via:
1. The web UI's **Environment → Network access: Full** (or Custom + add hosts), or
2. A custom environment image that includes these hosts in its proxy allowlist, or
3. The environment operator updating the default image.

This PR is still the right baseline so the setting is correct when anyone runs the skill locally, and documents the verified cloud-sandbox limitation.

## Test plan
- [x] `.claude/settings.json` is valid JSON (verified by Edit tool)
- [x] Setting matches the Claude Code `settings.json` schema (`sandbox.network.allowedDomains`)
- [ ] Local sandbox run of the `group-sequential-design` skill: `Rscript -e 'install.packages("gsDesign", repos="https://packagemanager.posit.co/cran/__linux__/noble/latest")'` succeeds (manual — requires a local macOS/Linux sandbox session)
- [ ] Cloud sandbox: follow up with web UI Network access setting or image update

https://claude.ai/code/session_01F6q4KiCVSSdA85NRhMir88