### PR TITLE
feat: track benchmark duration and token usage

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -50,18 +50,20 @@ Use the Agent tool (e.g., `generalist`) to launch both agents simultaneously for
 - Provide all files from `_bundled_resources` (e.g., `reference.md`, `examples.md`, `scripts/gsd_report_template.py`).
 - Provide any referenced `files` from the eval case.
 - Give the `prompt` from the eval case.
-- Instruct: "Follow the skill workflow to complete this task. Save all generated files into a directory named `output_A/`. Produce all expected outputs."
+- Instruct: "Follow the skill workflow to complete this task. Save all generated files into a directory named `output_A/`. Produce all expected outputs. **At the very end of your response, please state your best estimate of the total tokens used in this turn (input + output) using the format: `[USAGE: {total_tokens}]`.**"
 
 **Agent B — WITHOUT the skill:**
 - Give the exact same `prompt` and `files`.
-- Instruct: "Complete this task using only your base knowledge and tools. Do NOT use any SKILL.md or skill instructions. Save all generated files into a directory named `output_B/`. Produce all expected outputs."
+- Instruct: "Complete this task using only your base knowledge and tools. Do NOT use any SKILL.md or skill instructions. Save all generated files into a directory named `output_B/`. Produce all expected outputs. **At the very end of your response, please state your best estimate of the total tokens used in this turn (input + output) using the format: `[USAGE: {total_tokens}]`.**"
 
 Both agents use the same model (whichever model this session is running).
 
 **When the agents return:**
-- Record the end time and calculate duration **in minutes (rounded to 1 decimal place)**.
-- Extract total token usage from the agent response metadata.
-- **Calculate the total tokens used in this entire task (orchestrator session + both sub-agents).**
+- Extract the `[USAGE: {n}]` value from each agent's response.
+- Run the recording script to capture duration and tokens:
+  ```bash
+  python3 _automation/benchmark-runner/scripts/record_run_result.py --eval-id {id} --model {CURRENT_MODEL_NAME} --status completed --tokens-a {tokens_A} --tokens-b {tokens_B}
+  ```
 - Note any system errors, tool failures, or retries.
 
 ---
@@ -74,6 +76,8 @@ For each agent's output, evaluate against every assertion in the eval case:
 - Partial — partially met
 
 Score = (passes + 0.5 x partials) / total assertions, as a fraction and percentage.
+
+Retrieve the recorded duration from the most recent entry in `_automation/benchmark-runner/runs/runs.json`.
 
 Identify "Key Metrics" from the assertions (e.g., Sample Size, Power, Error Rates) to include in the scorecard for direct comparison.
 
@@ -115,7 +119,6 @@ Write a Markdown file at `/tmp/benchmark_comment_{skill}_{eval_id}.md` using thi
 | **Model** | `{model name}` |
 | **Skill version** | `{_skill_sha}` |
 | **Triggered by** | Scheduled/Manual |
-| **Total session tokens** | `{total_tokens}` |
 
 ### Scorecard
 

--- a/_automation/benchmark-runner/scripts/get_next_eval.py
+++ b/_automation/benchmark-runner/scripts/get_next_eval.py
@@ -86,6 +86,7 @@ def write_run_manifest(eval_case: dict, model: str, skill_sha: str, status: str)
         "skill_sha": skill_sha,
         "model": model,
         "run_date": datetime.now(timezone.utc).isoformat(),
+        "start_timestamp": datetime.now(timezone.utc).timestamp(),
         "status": status,
     }
     manifest_path = RUNS_DIR / "runs.json"

--- a/_automation/benchmark-runner/scripts/record_run_result.py
+++ b/_automation/benchmark-runner/scripts/record_run_result.py
@@ -1,0 +1,50 @@
+import json
+import argparse
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNS_DIR = REPO_ROOT / "_automation" / "benchmark-runner" / "runs"
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--eval-id", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--tokens-a", type=int, help="Tokens for Agent A")
+    parser.add_argument("--tokens-b", type=int, help="Tokens for Agent B")
+    args = parser.parse_args()
+
+    manifest_path = RUNS_DIR / "runs.json"
+    if not manifest_path.exists():
+        print("Error: Manifest not found", file=sys.stderr)
+        sys.exit(1)
+
+    with open(manifest_path, "r") as f:
+        records = json.load(f)
+
+    # Find the most recent "dispatched" record for this eval/model
+    found = False
+    for record in reversed(records):
+        if record.get("eval_id") == args.eval_id and record.get("model") == args.model and record.get("status") == "dispatched":
+            record["status"] = args.status
+            record["end_timestamp"] = datetime.now(timezone.utc).timestamp()
+            start = record.get("start_timestamp")
+            if start:
+                record["duration_sec"] = record["end_timestamp"] - start
+                record["duration_min"] = round(record["duration_sec"] / 60, 1)
+            
+            record["tokens_a"] = args.tokens_a
+            record["tokens_b"] = args.tokens_b
+            found = True
+            break
+
+    if not found:
+        print(f"Warning: No dispatched record found for {args.eval_id} and {args.model}", file=sys.stderr)
+
+    with open(manifest_path, "w") as f:
+        json.dump(records, f, indent=2)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updates the benchmark runner to track execution duration via start/end timestamps and requires sub-agents to self-report token usage, storing the results in the scorecard.