### PR TITLE
Use content hash instead of git SHA for skill versioning

### DIFF
--- a/_automation/benchmark-runner/scripts/get_next_eval.py
+++ b/_automation/benchmark-runner/scripts/get_next_eval.py
@@ -48,13 +48,14 @@ def check_github_comments(issue_id: str, target_sha: str, target_model: str) -> 
             ],
             capture_output=True, text=True, check=True,
         )
-    except subprocess.CalledProcessError as e:
-        # A transient gh failure means we cannot confirm — warn loudly but do not
-        # silently skip: return False so the benchmark still runs rather than being
-        # dropped entirely. The run manifest will record it for audit.
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        # A transient gh failure or missing gh binary means we cannot confirm —
+        # warn loudly but do not silently skip: return False so the benchmark
+        # still runs rather than being dropped entirely.
+        err_msg = e.stderr if isinstance(e, subprocess.CalledProcessError) else str(e)
         print(
             f"Warning: gh failed checking comments for issue {issue_id} — "
-            f"treating as pending (may cause a duplicate if transient): {e.stderr}",
+            f"treating as pending (may cause a duplicate if transient): {err_msg}",
             file=sys.stderr,
         )
         return False

--- a/_automation/benchmark-runner/scripts/get_next_eval.py
+++ b/_automation/benchmark-runner/scripts/get_next_eval.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import subprocess
 import argparse
@@ -18,18 +19,33 @@ def normalize_model_name(name: str) -> str:
     return re.sub(r"[\s\-_\.]", "", name.lower())
 
 
-def get_git_sha(skill_path: Path) -> str:
-    """Composite SHA over the entire skill directory, not just SKILL.md (fix 3.3)."""
-    try:
-        result = subprocess.run(
-            ["git", "log", "-n", "1", "--format=%H", "--", str(skill_path)],
-            capture_output=True, text=True, check=True, cwd=str(REPO_ROOT),
-        )
-        sha = result.stdout.strip()
-        return sha if sha else "unknown"
-    except subprocess.CalledProcessError as e:
-        print(f"Error: git log failed for {skill_path}: {e.stderr}", file=sys.stderr)
-        sys.exit(1)
+def get_skill_content_sha(skill_path: Path) -> str:
+    """SHA256 over the actual content of bundled skill files (.md, .py), excluding evals/.
+
+    Using content rather than git-commit SHA avoids false "new version" signals when
+    surrounding commits (e.g. moving eval files out of the skill directory) touch the
+    path without changing any skill file.  The hash is stable as long as the files
+    the agents actually receive are unchanged.
+    """
+    h = hashlib.sha256()
+    for root, dirs, files in os.walk(skill_path):
+        root_path = Path(root)
+        if root_path.name == "evals":
+            dirs.clear()
+            continue
+        dirs.sort()
+        for fname in sorted(files):
+            if not (fname.endswith(".md") or fname.endswith(".py")):
+                continue
+            fpath = root_path / fname
+            rel = str(fpath.relative_to(skill_path))
+            try:
+                content = fpath.read_bytes()
+                h.update(rel.encode())
+                h.update(content)
+            except OSError:
+                pass
+    return h.hexdigest()
 
 
 def check_github_comments(issue_id: str, target_sha: str, target_model: str) -> bool:
@@ -149,7 +165,7 @@ def main() -> None:
         if not (skill_path / "SKILL.md").exists():
             continue
 
-        skill_sha = get_git_sha(skill_path)
+        skill_sha = get_skill_content_sha(skill_path)
 
         if not check_github_comments(eval_id, skill_sha, args.model):
             eval_case["_skill_name"] = primary_skill_name

--- a/_automation/tests/test_benchmark_runner.py
+++ b/_automation/tests/test_benchmark_runner.py
@@ -102,29 +102,70 @@ class TestCheckGithubComments(unittest.TestCase):
         result = gne.check_github_comments("github-issue-21", "abc123", "claude-sonnet-4-6")
         self.assertFalse(result)
 
+    @patch("get_next_eval.subprocess.run")
+    def test_gh_missing_returns_false_with_warning(self, mock_run):
+        mock_run.side_effect = FileNotFoundError(2, "No such file or directory", "gh")
+        # Should not raise when gh binary is absent — returns False and prints warning
+        result = gne.check_github_comments("github-issue-21", "abc123", "claude-sonnet-4-6")
+        self.assertFalse(result)
+
     def test_invalid_issue_id_returns_false(self):
         self.assertFalse(gne.check_github_comments("not-a-valid-id", "sha", "model"))
 
 
-class TestGetGitSha(unittest.TestCase):
-    @patch("get_next_eval.subprocess.run")
-    def test_returns_sha(self, mock_run):
-        mock_run.return_value = MagicMock(stdout="deadbeef\n", returncode=0)
-        result = gne.get_git_sha(Path("/some/skill"))
-        self.assertEqual(result, "deadbeef")
+class TestGetSkillContentSha(unittest.TestCase):
+    def _make_skill_dir(self, tmp_path, files):
+        """Create a temporary skill directory with the given {rel_path: content} files."""
+        import os
+        skill_dir = Path(tmp_path) / "my-skill"
+        for rel, content in files.items():
+            fpath = skill_dir / rel
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content)
+        return skill_dir
 
-    @patch("get_next_eval.subprocess.run")
-    def test_empty_output_returns_unknown(self, mock_run):
-        mock_run.return_value = MagicMock(stdout="", returncode=0)
-        result = gne.get_git_sha(Path("/some/skill"))
-        self.assertEqual(result, "unknown")
+    def test_returns_hex_string(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill_dir(tmp, {"SKILL.md": "hello"})
+            sha = gne.get_skill_content_sha(skill_dir)
+            self.assertRegex(sha, r"^[0-9a-f]{64}$")
 
-    @patch("get_next_eval.subprocess.run")
-    def test_subprocess_error_exits(self, mock_run):
-        import subprocess
-        mock_run.side_effect = subprocess.CalledProcessError(128, "git", stderr="not a repo")
-        with self.assertRaises(SystemExit):
-            gne.get_git_sha(Path("/some/skill"))
+    def test_deterministic_same_files(self):
+        import tempfile
+        files = {"SKILL.md": "content A", "reference.md": "content B"}
+        with tempfile.TemporaryDirectory() as tmp1, tempfile.TemporaryDirectory() as tmp2:
+            sha1 = gne.get_skill_content_sha(self._make_skill_dir(tmp1, files))
+            sha2 = gne.get_skill_content_sha(self._make_skill_dir(tmp2, files))
+            self.assertEqual(sha1, sha2)
+
+    def test_different_content_gives_different_sha(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp1, tempfile.TemporaryDirectory() as tmp2:
+            sha1 = gne.get_skill_content_sha(self._make_skill_dir(tmp1, {"SKILL.md": "v1"}))
+            sha2 = gne.get_skill_content_sha(self._make_skill_dir(tmp2, {"SKILL.md": "v2"}))
+            self.assertNotEqual(sha1, sha2)
+
+    def test_excludes_evals_directory(self):
+        import tempfile
+        base_files = {"SKILL.md": "skill content"}
+        with tempfile.TemporaryDirectory() as tmp1, tempfile.TemporaryDirectory() as tmp2:
+            sha_without = gne.get_skill_content_sha(self._make_skill_dir(tmp1, base_files))
+            sha_with_evals = gne.get_skill_content_sha(
+                self._make_skill_dir(tmp2, {**base_files, "evals/case.json": '{"id":"test"}'})
+            )
+            # Adding a file under evals/ must not change the hash
+            self.assertEqual(sha_without, sha_with_evals)
+
+    def test_ignores_non_md_py_files(self):
+        import tempfile
+        base_files = {"SKILL.md": "content"}
+        with tempfile.TemporaryDirectory() as tmp1, tempfile.TemporaryDirectory() as tmp2:
+            sha1 = gne.get_skill_content_sha(self._make_skill_dir(tmp1, base_files))
+            sha2 = gne.get_skill_content_sha(
+                self._make_skill_dir(tmp2, {**base_files, "data.csv": "a,b,c"})
+            )
+            self.assertEqual(sha1, sha2)
 
 
 class TestWriteRunManifest(unittest.TestCase):


### PR DESCRIPTION
## Summary
Changed skill versioning from git commit SHA to SHA256 hash of actual skill content files. This prevents false "new version" signals when surrounding commits modify the skill directory path without changing the actual skill files that agents receive.

## Key Changes
- Replaced `get_git_sha()` with `get_skill_content_sha()` that computes SHA256 over bundled skill files (.md, .py)
- Content hash excludes the `evals/` subdirectory to avoid spurious version changes when evaluation files are reorganized
- Hash is computed deterministically by sorting directories and files, ensuring stable results
- Improved error handling in `check_github_comments()` to handle both subprocess failures and missing `gh` binary
- Updated error message formatting to work with both exception types

## Implementation Details
- The new hash function walks the skill directory tree, filtering for `.md` and `.py` files only
- File paths and content are both included in the hash to ensure uniqueness
- The `evals/` directory is explicitly skipped during traversal to prevent unrelated evaluation file changes from affecting the skill version
- OSError exceptions during file reading are silently ignored to handle edge cases gracefully

https://claude.ai/code/session_01SrvHxW2E8pUiT9F5E6iR4G