### PR TITLE
Improve R package installation robustness with OS detection and fallback

### DIFF
--- a/_automation/benchmark-runner/scripts/setup_r_env.sh
+++ b/_automation/benchmark-runner/scripts/setup_r_env.sh
@@ -20,9 +20,37 @@ echo "[setup] R ${R_VERSION} available."
 # 2. Install required R packages via Posit Public Package Manager
 #    (pre-compiled Linux binaries — much faster than building from source)
 # ---------------------------------------------------------------------------
-Rscript - <<'REOF'
+
+# Detect OS codename for the correct PPM binary URL (e.g. noble, jammy, focal)
+OS_CODENAME=$(. /etc/os-release 2>/dev/null && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}" || true)
+if [ -z "${OS_CODENAME}" ] && command -v lsb_release &>/dev/null; then
+  OS_CODENAME=$(lsb_release -cs 2>/dev/null || true)
+fi
+
+if [ -n "${OS_CODENAME}" ]; then
+  PPM_URL="https://packagemanager.posit.co/cran/__linux__/${OS_CODENAME}/latest"
+  echo "[setup] Detected OS codename '${OS_CODENAME}' — using PPM URL: ${PPM_URL}"
+else
+  PPM_URL="https://cloud.r-project.org"
+  echo "[setup] Could not detect OS codename — falling back to CRAN: ${PPM_URL}"
+fi
+
+Rscript --no-save - "${PPM_URL}" <<'REOF'
+ppm_url <- commandArgs(trailingOnly = TRUE)[1]
+
+# Verify the PPM URL is reachable and has packages; fall back to CRAN if not
+ppm_ok <- tryCatch({
+  av <- available.packages(repos = ppm_url)
+  nrow(av) > 100
+}, error = function(e) FALSE)
+
+repo_url <- if (ppm_ok) ppm_url else {
+  message("[setup] PPM URL unreachable — falling back to CRAN")
+  "https://cloud.r-project.org"
+}
+
 options(
-  repos = c(CRAN = "https://packagemanager.posit.co/cran/__linux__/jammy/latest"),
+  repos = c(CRAN = repo_url),
   warn  = 1   # print warnings immediately
 )
 
@@ -49,7 +77,7 @@ missing   <- all_pkgs[!all_pkgs %in% installed]
 
 if (length(missing) > 0) {
   message("[setup] Installing missing packages: ", paste(missing, collapse = ", "))
-  install.packages(missing, quiet = FALSE)
+  install.packages(missing, quiet = FALSE, dependencies = TRUE)
 }
 
 # Verify every package can actually be loaded


### PR DESCRIPTION
## Summary
Enhanced the R environment setup script to dynamically detect the Ubuntu OS codename and intelligently handle Posit Package Manager (PPM) availability with automatic fallback to CRAN, making the setup more portable and resilient across different Linux distributions.

## Key Changes
- **OS Detection**: Added logic to detect the Ubuntu codename (`noble`, `jammy`, `focal`, etc.) from `/etc/os-release` or `lsb_release`, enabling the correct PPM binary URL to be constructed dynamically instead of hardcoding `jammy`
- **PPM Availability Check**: Implemented a verification step in R that tests whether the detected PPM URL is reachable and contains packages before using it; automatically falls back to CRAN if PPM is unavailable
- **Dependency Installation**: Added `dependencies = TRUE` flag to `install.packages()` to ensure all package dependencies are properly installed
- **Improved Logging**: Added informative messages indicating which repository URL is being used and why

## Implementation Details
- The OS codename detection uses a fallback chain: first tries `/etc/os-release`, then `lsb_release` command
- The R script now accepts the PPM URL as a command-line argument via `commandArgs()`
- The PPM availability check validates that at least 100 packages are available from the repository to ensure it's functional
- If PPM detection fails at any point, the script gracefully falls back to the official CRAN mirror

https://claude.ai/code/session_01EJwFGWCxY2A7Yo5UPNBruz