### PR TITLE
Enhance R package installation with pak, system deps, and DNS pin

### DIFF
--- a/_automation/README.md
+++ b/_automation/README.md
@@ -31,15 +31,18 @@ If using a cloud CLI platform (like claude.ai/code, or equivalent Gemini/OpenAI 
     ```
     cran.r-project.org
     cloud.r-project.org
-    cran.rstudio.com
+    r-lib.github.io
+    packagemanager.posit.co
     *.r-project.org
     ```
 - **Setup script** (installs R and pre-caches key packages — result is cached, runs once):
   ```bash
   #!/bin/bash
-  apt-get update -qq && apt-get install -y --no-install-recommends r-base
-  Rscript -e "install.packages(c('gsDesign', 'rpact', 'jsonlite'), repos='https://cloud.r-project.org')"
+  bash _automation/benchmark-runner/scripts/setup_r_env.sh
   ```
+  The script handles everything: installs R, system build libraries, pins CRAN to a
+  stable IP to avoid DNS failures, bootstraps `pak`, and installs all required packages
+  in parallel using pre-compiled binaries where available.
 
 ### 2. Create the routine
 

--- a/_automation/README.md
+++ b/_automation/README.md
@@ -31,18 +31,15 @@ If using a cloud CLI platform (like claude.ai/code, or equivalent Gemini/OpenAI 
     ```
     cran.r-project.org
     cloud.r-project.org
-    r-lib.github.io
-    packagemanager.posit.co
+    cran.rstudio.com
     *.r-project.org
     ```
 - **Setup script** (installs R and pre-caches key packages — result is cached, runs once):
   ```bash
   #!/bin/bash
-  bash _automation/benchmark-runner/scripts/setup_r_env.sh
+  apt-get update -qq && apt-get install -y --no-install-recommends r-base
+  Rscript -e "install.packages(c('gsDesign', 'rpact', 'jsonlite'), repos='https://cloud.r-project.org')"
   ```
-  The script handles everything: installs R, system build libraries, pins CRAN to a
-  stable IP to avoid DNS failures, bootstraps `pak`, and installs all required packages
-  in parallel using pre-compiled binaries where available.
 
 ### 2. Create the routine
 

--- a/group-sequential-design/README.md
+++ b/group-sequential-design/README.md
@@ -85,10 +85,9 @@ output/gsd_{disease}_{endpoints}_{YYYYMMDD}/
                    └── evals.json
    ```
 
-2. Install the required R packages (uses `pak` for parallel, binary-first installs):
+2. Install the required R packages:
    ```r
-   install.packages("pak")
-   pak::pak(c("gsDesign", "gsDesign2", "lrstat", "graphicalMCP", "jsonlite"))
+   install.packages(c("gsDesign", "gsDesign2", "lrstat", "graphicalMCP", "jsonlite"))
    ```
 
 3. Install the required Python package:

--- a/group-sequential-design/README.md
+++ b/group-sequential-design/README.md
@@ -85,9 +85,10 @@ output/gsd_{disease}_{endpoints}_{YYYYMMDD}/
                    └── evals.json
    ```
 
-2. Install the required R packages:
+2. Install the required R packages (uses `pak` for parallel, binary-first installs):
    ```r
-   install.packages(c("gsDesign", "gsDesign2", "lrstat", "graphicalMCP", "jsonlite"))
+   install.packages("pak")
+   pak::pak(c("gsDesign", "gsDesign2", "lrstat", "graphicalMCP", "jsonlite"))
    ```
 
 3. Install the required Python package:


### PR DESCRIPTION
## Summary

- **`setup_r_env.sh`**: Rewrites the R bootstrap to use `pak` for parallel, binary-first package installation; pre-installs required system libraries via apt; and pins `cran.r-project.org` to a stable IP in `/etc/hosts` to prevent "DNS cache overflow" failures observed under connection load.
- **`_automation/README.md`**: Replaces the outdated inline `install.packages()` setup script snippet with a single call to `setup_r_env.sh`, and adds `r-lib.github.io` + `packagemanager.posit.co` to the network allowlist so pak's CDN and PPM binary downloads are not blocked in cloud environments.

## Motivation

During live benchmark runs the old script hit three failure modes:
1. PPM returned HTTP 503 for package tarballs → R fell back to compiling everything from source (20-30 min instead of ~2 min)
2. R's internal download engine hit "DNS cache overflow" under concurrent connections → package downloads silently failed
3. Missing system headers (`libcurl4-openssl-dev`, `libfreetype-dev`, `libuv1-dev`, etc.) caused C/C++ package builds to fail mid-install

## Changes in `setup_r_env.sh`

| Step | What it does |
|---|---|
| Pre-install system libs | `apt-get install` of all known C/C++ headers upfront, avoiding mid-R-session compile failures |
| DNS pin | Resolves `cran.r-project.org` and `cloud.r-project.org` once via curl and writes to `/etc/hosts`; idempotent |
| Bootstrap `pak` | Tries pak's own r-lib CDN first (no CRAN dependency), falls back to CRAN with `curl -k` |
| Install packages | `pak::pak()` with `upgrade = FALSE` — parallel downloads, system-req detection, binary preference |

## Test plan

- [ ] Run `bash _automation/benchmark-runner/scripts/setup_r_env.sh` on a fresh Ubuntu Noble session and confirm it exits 0 with `[setup] R environment ready.`
- [ ] Confirm all 8 packages (`jsonlite`, `digest`, `gsDesign`, `gsDesign2`, `lrstat`, `graphicalMCP`, `eventPred`, `ggplot2`) load successfully
- [ ] Verify the script is idempotent: running it a second time skips installation and exits cleanly

https://claude.ai/code/session_017p3BoyxkzseUaeCWJLBCRV