### PR TITLE
Update benchmark launcher commands to use pipe syntax

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -117,8 +117,8 @@ Text files are also embedded in `_common_task_prompt` under neutral names such a
 Example launcher shape for each side:
 
 ```bash
-cd /tmp/benchmark_{id}/agent_A && claude -p "$(cat prompt_A.txt)" --model "{CURRENT_MODEL_NAME}" --allowedTools "Bash,Read,Write,Edit,Glob"
-cd /tmp/benchmark_{id}/agent_B && claude -p "$(cat prompt_B.txt)" --model "{CURRENT_MODEL_NAME}" --allowedTools "Bash,Read,Write,Edit,Glob"
+cd /tmp/benchmark_{id}/agent_A && cat prompt_A.txt | claude -p --model "{CURRENT_MODEL_NAME}" --allowedTools "Bash,Read,Write,Edit,Glob"
+cd /tmp/benchmark_{id}/agent_B && cat prompt_B.txt | claude -p --model "{CURRENT_MODEL_NAME}" --allowedTools "Bash,Read,Write,Edit,Glob"
 ```
 
 `prompt_A.txt` should contain only the skill context plus `_prompt_a`. `prompt_B.txt` should


### PR DESCRIPTION
## Summary
Updated the example launcher commands in the SKILL benchmark documentation to use pipe syntax for passing prompts to the Claude CLI instead of command substitution.

## Key Changes
- Changed from `claude -p "$(cat prompt_A.txt)"` to `cat prompt_A.txt | claude -p` for agent_A launcher
- Changed from `claude -p "$(cat prompt_B.txt)"` to `cat prompt_B.txt | claude -p` for agent_B launcher
- This simplifies the command syntax and makes it more readable while maintaining the same functionality

## Details
The pipe syntax is a cleaner alternative to command substitution for passing file contents to the Claude CLI. This change makes the example commands easier to understand and follow for users implementing the benchmark runner.

https://claude.ai/code/session_01YNfQp8cADEQJPm2fddJkGL