### PR TITLE
benchmark-runner: upsert comment instead of always creating a new one

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -334,22 +334,51 @@ or `result`. The `result` line contains API-reported `usage.input_tokens` /
 
 Extract the issue number from the `id` (e.g., `"github-issue-21"` -> **#21**).
 
-**Primary — MCP tool (no token required):**
-Use the `mcp__github__add_issue_comment` tool:
-```
-owner: RConsortium
-repo:  pharma-skills
-issue_number: {issue_number}
-body: <contents of /tmp/benchmark_comment_{skill}_{eval_id}.md>
-```
+If a benchmark result for the same model already exists on the issue, **update it** instead
+of creating a new comment. "Same model" is detected by scanning comment bodies for the string
+`"Automated Benchmark Results"` together with the model name (e.g. `claude-sonnet-4-6`).
+
+**Primary — MCP tools (no token required):**
+
+1. Fetch existing comments with `mcp__github__issue_read`:
+   ```
+   method: get_comments
+   owner:  RConsortium
+   repo:   pharma-skills
+   issue_number: {issue_number}
+   ```
+2. Scan the returned comments for one whose `body` contains both
+   `"Automated Benchmark Results"` and `{CURRENT_MODEL_NAME}`.
+   - **Found** — note its `id`, then PATCH it via REST:
+     ```bash
+     curl -s -X PATCH \
+       -H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}" \
+       -H "Accept: application/vnd.github+json" \
+       -H "Content-Type: application/json" \
+       https://api.github.com/repos/RConsortium/pharma-skills/issues/comments/{comment_id} \
+       --data-binary @/tmp/benchmark_comment_{skill}_{eval_id}.md \
+       | python3 -c "import json,sys; print(json.load(sys.stdin).get('html_url',''))"
+     ```
+     > Note: `--data-binary` sends raw JSON body. Wrap the file contents in `{"body": "..."}` if using a JSON payload builder.
+   - **Not found** — create a new comment with `mcp__github__add_issue_comment`:
+     ```
+     owner: RConsortium
+     repo:  pharma-skills
+     issue_number: {issue_number}
+     body: <contents of /tmp/benchmark_comment_{skill}_{eval_id}.md>
+     ```
 
 **Fallback — REST API (requires `GH_TOKEN` or `GITHUB_TOKEN`):**
-If the MCP tool is unavailable or returns an error, use the Python fallback script:
+If the MCP tool is unavailable or returns an error, the Python script handles the full
+upsert automatically:
 ```bash
 python3 _automation/benchmark-runner/scripts/post_issue_comment.py {issue_number} \
   --repo RConsortium/pharma-skills \
-  --body-file /tmp/benchmark_comment_{skill}_{eval_id}.md
+  --body-file /tmp/benchmark_comment_{skill}_{eval_id}.md \
+  --model {CURRENT_MODEL_NAME}
 ```
+Pass `--model` so the script can find and update an existing comment. Without `--model` it
+always creates a new comment.
 
 ---
 

--- a/_automation/benchmark-runner/scripts/post_issue_comment.py
+++ b/_automation/benchmark-runner/scripts/post_issue_comment.py
@@ -9,19 +9,21 @@ from typing import Optional
 
 DEFAULT_REPO = os.environ.get("PHARMA_SKILLS_GITHUB_REPO", "RConsortium/pharma-skills")
 
+BENCHMARK_MARKER = "Automated Benchmark Results"
+
 
 def get_github_token() -> Optional[str]:
     return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
 
 
-def post_issue_comment(repo: str, issue_number: str, body: str) -> str:
+def _api_request(url: str, method: str = "GET", payload: Optional[dict] = None) -> dict:
     token = get_github_token()
     if not token:
         raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is not set")
-
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
     request = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
-        data=json.dumps({"body": body}).encode("utf-8"),
+        url,
+        data=data,
         headers={
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {token}",
@@ -29,30 +31,87 @@ def post_issue_comment(repo: str, issue_number: str, body: str) -> str:
             "X-GitHub-Api-Version": "2022-11-28",
             "User-Agent": "pharma-skills-benchmark-runner",
         },
-        method="POST",
+        method=method,
     )
     with urllib.request.urlopen(request, timeout=30) as response:
-        data = json.loads(response.read().decode("utf-8"))
+        return json.loads(response.read().decode("utf-8"))
+
+
+def find_existing_comment(repo: str, issue_number: str, model: str) -> Optional[int]:
+    """Return the comment ID of an existing benchmark result for this model, or None."""
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+            f"?per_page=100&page={page}"
+        )
+        comments = _api_request(url)
+        for c in comments:
+            body = c.get("body", "")
+            if BENCHMARK_MARKER in body and model in body:
+                return c["id"]
+        if len(comments) < 100:
+            break
+        page += 1
+    return None
+
+
+def post_issue_comment(repo: str, issue_number: str, body: str) -> str:
+    data = _api_request(
+        f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments",
+        method="POST",
+        payload={"body": body},
+    )
     return data.get("html_url", "")
+
+
+def update_issue_comment(repo: str, comment_id: int, body: str) -> str:
+    data = _api_request(
+        f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}",
+        method="PATCH",
+        payload={"body": body},
+    )
+    return data.get("html_url", "")
+
+
+def upsert_issue_comment(repo: str, issue_number: str, body: str, model: str) -> tuple[str, str]:
+    """Post a new comment or update the existing one for this model. Returns (url, action)."""
+    comment_id = find_existing_comment(repo, issue_number, model)
+    if comment_id is not None:
+        url = update_issue_comment(repo, comment_id, body)
+        return url, "updated"
+    url = post_issue_comment(repo, issue_number, body)
+    return url, "created"
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Post a GitHub issue comment through REST API without gh."
+        description="Post or update a GitHub issue comment through REST API without gh."
     )
     parser.add_argument("issue_number", help="GitHub issue number to comment on")
     parser.add_argument("--repo", default=DEFAULT_REPO, help="Repository in owner/name form")
     parser.add_argument("--body-file", required=True, help="Markdown file to post")
+    parser.add_argument(
+        "--model",
+        help=(
+            "Model name as it appears in the comment body. When provided, an existing "
+            "benchmark comment for this model is updated instead of creating a new one."
+        ),
+    )
     args = parser.parse_args()
 
     try:
         body = Path(args.body_file).read_text()
-        comment_url = post_issue_comment(args.repo, args.issue_number, body)
+        if args.model:
+            url, action = upsert_issue_comment(args.repo, args.issue_number, body, args.model)
+        else:
+            url = post_issue_comment(args.repo, args.issue_number, body)
+            action = "created"
     except (OSError, RuntimeError, urllib.error.URLError, urllib.error.HTTPError) as e:
         print(f"Error posting issue comment: {e}", file=sys.stderr)
         sys.exit(1)
 
-    print(comment_url or "Comment posted")
+    print(f"Comment {action}: {url or '(no URL returned)'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
post_issue_comment.py gains --model and upsert logic: it scans existing issue comments for one that contains both "Automated Benchmark Results" and the model name, PATCHes it if found, and falls back to a new POST otherwise. The find/update helpers share a single _api_request() function to avoid code duplication.

SKILL.md Step 6 is updated to match:
- Primary path uses mcp__github__issue_read (get_comments) to find an existing comment, then REST PATCH to update it or mcp__github__add_issue_comment to create it.
- Fallback path passes --model to post_issue_comment.py so the upsert runs automatically.

https://claude.ai/code/session_01SrsyMEN4DsXSBzBhDwovJ1