### PR TITLE
Clarify benchmark verdict criteria to avoid length bias

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -264,11 +264,17 @@ Write a Markdown file at `/tmp/benchmark_comment_{skill}_{eval_id}.md` using thi
 
 ### Key Observations
 
-- {2-4 bullet points comparing both agents}
+- {2-4 bullet points comparing both agents — ground each point in assertion outcomes or
+  factual execution differences (score, turns, tokens, files produced). Do not characterize
+  one response as "richer" or "better" based on output length or artifact count unless an
+  assertion explicitly requires it. If both agents pass the same assertions, state that.}
 
 ### Verdict
 
-{1-2 sentence overall verdict}
+{1-2 sentence overall verdict — state the assertion outcome first, then any meaningful
+execution difference (cost, speed). Do not invent a qualitative winner when both agents
+satisfy the same assertions. A short correct answer and a long correct answer are equal
+if no assertion distinguishes them.}
 
 ---
 

--- a/_automation/benchmark-runner/scripts/get_next_eval.py
+++ b/_automation/benchmark-runner/scripts/get_next_eval.py
@@ -286,7 +286,9 @@ def build_agent_prompts(eval_case: dict) -> None:
         "Assertions:\n"
         + "\n".join(f"- {assertion}" for assertion in eval_case.get("assertions", []))
         + "\n\nReturn a concise score table with Pass, Partial, or Fail for each "
-        "assertion and each candidate. Do not mention or infer treatment labels."
+        "assertion and each candidate. Do not mention or infer treatment labels. "
+        "Do not reward output length or artifact count unless an assertion requires it — "
+        "a short correct answer and a long correct answer are equal if both satisfy all assertions."
     )
 
     blind_seed = hashlib.sha256(


### PR DESCRIPTION
## Summary
Updated benchmark evaluation guidance to prevent evaluators from favoring longer or more artifact-heavy responses when both agents satisfy the same assertions. This ensures fair comparison based on assertion outcomes rather than output characteristics.

## Key Changes
- **SKILL.md**: Enhanced "Key Observations" and "Verdict" sections with explicit instructions to:
  - Ground comparisons in assertion outcomes and factual execution metrics (score, turns, tokens, files)
  - Avoid characterizing responses as "richer" or "better" based solely on length or artifact count
  - Acknowledge when both agents pass identical assertions
  - Treat short and long correct answers as equal when no assertion distinguishes them

- **get_next_eval.py**: Added clarification to the agent scoring prompt to:
  - Explicitly state that output length and artifact count should not be rewarded unless required by an assertion
  - Reinforce that both short and long correct answers are equivalent if they satisfy all assertions

## Implementation Details
These changes are purely instructional/guidance updates with no functional code logic changes. They serve to standardize evaluator behavior and reduce subjective bias in benchmark comparisons by anchoring all verdicts to explicit assertion requirements rather than qualitative output characteristics.

https://claude.ai/code/session_019JaRMFBffFB4NaNbc37xit