### PR TITLE
Expand community section with link to pilot 7 and how to join page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,20 @@ You can add new benchmark data by creating new github issues following the `benc
 
 If you're interested in contributing to the skill evaluation using your Claude Code account, following this [video](https://github.com/user-attachments/assets/05d24707-36b8-49fc-86ea-beb6365e288e) to set it up.
 
-## Community
-
-Join our ongoing discussions, seek help, or propose new AI skills in our dedicated Slack channel:
-- **[RConsortium Pharma Skills Slack](https://app.slack.com/client/TUMBMR083/C0AR7L8GR5Z)**
-
 ## License
 
 All skills in this repository are required to be licensed under the MIT License to ensure maximum permissiveness and rapid adoption within pharmaceutical research.
+
+
+## Join Us
+
+This effort is the part B of R consortium Submissions Working Group [Pilot 7](https://github.com/RConsortium/submissions-pilot7-synthetic-data). The pilot 7 aims at developing modern, realistic synthetic clinical trial benchmark datasets and test cases to evaluate open-source clinical data science tools and pharma AI “skills,” starting with group sequential design.
+
+Pilot 7 holds weekly standups three times a month on Fridays from 8–9 AM PST. We also host monthly Submissions Working Group meetings with FDA staff, bringing together participants across different pilot subgroups.
+
+[Pilot 7 Meeting minutes](https://github.com/RConsortium/submissions-pilot7-synthetic-data/wiki/Meeting-Minutes)
+
+Everyone is welcome to join. To access our calendar and join the Slack workspace, please see 
+[here](https://rconsortium.github.io/submissions-wg/join.html)
+
+To learn more about the R consortium Submissions Working Group, visit [here](https://rconsortium.github.io/submissions-wg/)


### PR DESCRIPTION
Added information about the R Consortium Submissions Working Group and Pilot 7, including meeting details and links.