### PR TITLE
setup_r_env.sh: install pak from source for proxy-CA compatibility

### DIFF
--- a/_automation/benchmark-runner/CLAUDE_CODE_ROUTINE.md
+++ b/_automation/benchmark-runner/CLAUDE_CODE_ROUTINE.md
@@ -13,15 +13,15 @@ https://github.com/RConsortium/pharma-skills/blob/main/_automation/benchmark-run
 ## Allowed Domain 
 
 ```
-cran.r-project.org
 *.r-project.org
-cloud.r-project.org
-packagemanager.posit.co
-rspm-sync.rstudio.com
 *.posit.co
-bioconductor.org
+rspm-sync.rstudio.com
 *.bioconductor.org
 github.com
 *.githubusercontent.com
 ppa.launchpadcontent.net
+archive.ubuntu.com
+security.ubuntu.com
+download.docker.com
+r-lib.github.io
 ```

--- a/_automation/benchmark-runner/scripts/setup_r_env.sh
+++ b/_automation/benchmark-runner/scripts/setup_r_env.sh
@@ -62,45 +62,80 @@ pin_host "cloud.r-project.org"
 # ---------------------------------------------------------------------------
 # 4. Bootstrap pak — the fast parallel package manager for R.
 #    pak: parallel downloads, automatic system-dep detection, binary packages.
+#
 #    Install strategy (in order of preference):
-#      a) Already installed → skip.
-#      b) pak's own r-lib CDN (independent of CRAN, pre-built binaries).
-#      c) CRAN with curl + SSL-bypass fallback.
+#      a) Already installed AND built for linux-gnu → skip.
+#         A pre-existing linux-musl build (from the r-lib CDN) is treated
+#         as unusable here because its statically-linked libcurl ships with
+#         a vendored CA bundle and ignores CURL_CA_BUNDLE / SSL_CERT_FILE.
+#         In sandboxes behind a TLS-intercepting egress proxy that signs
+#         with a custom root CA, that build fails every CRAN/Bioc fetch
+#         with "self signed certificate in certificate chain". We remove it
+#         and reinstall from source.
+#      b) Install from source via CRAN. The resulting pak links against
+#         system libcurl/openssl (libcurl4-openssl-dev + libssl-dev from
+#         Step 2), which honor the system CA bundle and any proxy CAs in
+#         /etc/ssl/certs/ca-certificates.crt.
+#      c) r-lib CDN pre-built binary as a last resort. Faster on
+#         unrestricted networks but may fail at runtime in proxied
+#         sandboxes (see strategy a).
 # ---------------------------------------------------------------------------
 echo "[setup] Checking for pak..."
 Rscript --no-save -e "
-if (requireNamespace('pak', quietly = TRUE)) {
-  message('[setup] pak ', as.character(packageVersion('pak')), ' already installed.')
-  quit(status = 0)
+pak_platform_ok <- function() {
+  sitrep <- utils::capture.output(pak::pak_sitrep())
+  any(grepl('pak platform:.*linux-gnu', sitrep))
 }
-message('[setup] Installing pak...')
 
-# Strategy (a): pak CDN — pre-built binaries, no CRAN dependency
-cdn_url <- sprintf(
-  'https://r-lib.github.io/p/pak/stable/%s/%s/%s',
-  .Platform\$pkgType, R.Version()\$os, R.Version()\$arch
-)
+if (requireNamespace('pak', quietly = TRUE)) {
+  if (isTRUE(try(pak_platform_ok(), silent = TRUE))) {
+    message('[setup] pak ', as.character(packageVersion('pak')),
+            ' (linux-gnu) already installed.')
+    quit(status = 0)
+  }
+  message('[setup] Existing pak is not a linux-gnu build — removing and ',
+          'reinstalling from source so it uses system libcurl/openssl.')
+  try(utils::remove.packages('pak'), silent = TRUE)
+}
+
+message('[setup] Installing pak from source (links against system ',
+        'libcurl/openssl so the system CA bundle is honored)...')
+
+# Strategy (b): source install from CRAN. Requires libcurl4-openssl-dev +
+# libssl-dev, which Step 2 already installs.
 ok <- tryCatch({
-  install.packages('pak', repos = cdn_url, quiet = TRUE)
+  install.packages(
+    'pak',
+    type  = 'source',
+    repos = 'https://cloud.r-project.org',
+    quiet = FALSE
+  )
   requireNamespace('pak', quietly = TRUE)
 }, error = function(e) FALSE, warning = function(w) FALSE)
 
 if (ok) {
-  message('[setup] pak installed from r-lib CDN.')
+  message('[setup] pak ', as.character(packageVersion('pak')),
+          ' installed from CRAN source.')
   quit(status = 0)
 }
 
-# Strategy (b): CRAN with curl download method and SSL bypass
-message('[setup] r-lib CDN failed — trying CRAN...')
-options(download.file.method = 'curl', download.file.extra = '-k')
+# Strategy (c): pak CDN binary fallback — may not work behind a
+# TLS-intercepting proxy, but works on unrestricted networks.
+message('[setup] CRAN source build failed — trying r-lib CDN binary...')
+cdn_url <- sprintf(
+  'https://r-lib.github.io/p/pak/stable/%s/%s/%s',
+  .Platform\$pkgType, R.Version()\$os, R.Version()\$arch
+)
 tryCatch({
-  install.packages('pak', repos = 'https://cran.r-project.org', quiet = FALSE)
-}, error = function(e) stop('[setup] Failed to install pak: ', conditionMessage(e)))
+  install.packages('pak', repos = cdn_url, quiet = FALSE)
+}, error = function(e) stop('[setup] Failed to install pak: ',
+                            conditionMessage(e)))
 
 if (!requireNamespace('pak', quietly = TRUE)) {
   stop('[setup] pak installed but cannot be loaded.')
 }
-message('[setup] pak ', as.character(packageVersion('pak')), ' installed from CRAN.')
+message('[setup] pak ', as.character(packageVersion('pak')),
+        ' installed from r-lib CDN.')
 " 2>&1
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Step 4 of `_automation/benchmark-runner/scripts/setup_r_env.sh` now installs **pak from source** via CRAN as the primary path. This links pak against the system libcurl/openssl, which honor `/etc/ssl/certs/ca-certificates.crt` — required in sandboxes behind a TLS-intercepting egress proxy that signs with a custom root CA. The previously-primary r-lib CDN ships a statically-linked `linux-musl` build with a vendored CA bundle that ignores `CURL_CA_BUNDLE`/`SSL_CERT_FILE`, so every CRAN/Bioc fetch fails with `self signed certificate in certificate chain`.
- An existing pak is now sanity-checked via `pak::pak_sitrep()`. If it's not a `linux-gnu` build (i.e. the musl CDN binary), it is removed and rebuilt from source.
- The r-lib CDN binary remains as a final fallback for unrestricted networks.
- Updates the allowed-domain list in `_automation/benchmark-runner/CLAUDE_CODE_ROUTINE.md` to include `archive.ubuntu.com`, `security.ubuntu.com`, `download.docker.com`, and `r-lib.github.io` (and consolidates `*.r-project.org`, `*.posit.co`, `*.bioconductor.org` wildcards).

No new system dependencies — `libcurl4-openssl-dev` and `libssl-dev` are already pulled in by Step 2.

## Test plan

- [x] R 4.3.3 installed via `apt`
- [x] `bash _automation/benchmark-runner/scripts/setup_r_env.sh` runs end-to-end
- [x] `pak::pak_sitrep()` reports `pak platform: x86_64-pc-linux-gnu`
- [x] `pak::repo_status()` shows CRAN `ok = TRUE`
- [x] `pak::pkg_install("gsDesign")` succeeds; `library(gsDesign)` + a 3-look O'Brien-Fleming design produce expected boundaries
- [x] `setup_r_env.sh` verifies all 8 required R packages load (gsDesign, gsDesign2, lrstat, graphicalMCP, eventPred, ggplot2, jsonlite, digest)

https://claude.ai/code/session_01W4TkuamWFxcuRKfyqFQLg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4TkuamWFxcuRKfyqFQLg3)_