### PR TITLE
chore: pause scheduled benchmarks workflow

### DIFF
--- a/.github/workflows/benchmark-schedule.yml
+++ b/.github/workflows/benchmark-schedule.yml
@@ -18,8 +18,8 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    # Only run in the upstream repo, not in forks (avoids leaking secrets)
-    if: github.repository == 'RConsortium/pharma-skills'
+    # PAUSED: The API is not yet ready.
+    if: false && github.repository == 'RConsortium/pharma-skills'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Pausing the scheduled benchmarks workflow as the API is not yet ready.