### PR TITLE
group-sequential-design: add Pacing — one artifact per turn rule

### DIFF
--- a/group-sequential-design/SKILL.md
+++ b/group-sequential-design/SKILL.md
@@ -39,6 +39,15 @@ When the conversation gets long and context is compressed, preserve information 
 
 This gives the user a visual progress indicator (spinner → checkmark) throughout the computation.
 
+**Pacing — one artifact per turn.** Do not bundle multiple major artifacts into a single response. Each of these is its own turn:
+- Writing `gsd_design.R` (then stop — let the tool result come back)
+- Running `gsd_design.R` (then stop)
+- Writing `gsd_verification.R`
+- Running the verification
+- Writing the report
+
+When you call `Write` for a script, do not also include long reasoning or a parallel `Bash` execution in the same turn. Save explanations for the final report. This keeps each assistant turn well under the output token cap and avoids truncation.
+
 ---
 
 1. **Create output subfolder** — If the user specifies an output directory path (e.g., "write all outputs to /some/path"), use that exact path as `out_dir` and create it. Otherwise, immediately after the user answers Q1 (disease/setting), create `output/gsd_{disease}_{endpoints}_{YYYYMMDD}/` (e.g., `output/gsd_1l_mnsclc_pfs_os_20260327/`). Use a placeholder for `{endpoints}` if not yet known (e.g., `output/gsd_1l_mnsclc_20260327/`), and rename later once endpoints are confirmed. ALL outputs — including any exploratory plots or comparisons generated during the Q&A phase — go in this subfolder.


### PR DESCRIPTION
## Summary
- Adds a **Pacing — one artifact per turn** rule to `group-sequential-design/SKILL.md` under the existing Task Progress Tracking section.
- Instructs the model to write or run each artifact (`gsd_design.R`, verification script, report) as its own turn rather than bundling them into one mega-response.

## Why
During a local benchmark run for issue #74, Agent A repeatedly hit the Claude Code 32 K `max_tokens` output cap mid-turn (the model was writing the R script, executing it, and starting the report all in one assistant turn). The fix isn't to keep raising the cap — 64 K is already the model ceiling — it's to break the work into smaller turns. This rule encodes that pattern into the skill so every user gets it, not just the benchmark runner.

## Test plan
- [ ] Manual: invoke `group-sequential-design` on a non-trivial trial design and confirm the model writes one artifact per assistant turn instead of bundling.
- [ ] Re-run a benchmark eval (e.g. issue #74) and verify Agent A produces output files without `max_tokens` truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)