### PR TITLE
Add clinical-trial-simulation to automation config

### DIFF
--- a/_automation/config.json
+++ b/_automation/config.json
@@ -6,6 +6,13 @@
       "priority": "high",
       "benchmark_schedule": "on_change",
       "description": "Design group sequential clinical trials for survival endpoints"
+    },
+    {
+      "name": "clinical-trial-simulation",
+      "dir": "clinical-trial-simulation",
+      "priority": "medium",
+      "benchmark_schedule": "on_change",
+      "description": "Design and simulate clinical trials using the TrialSimulator R package"
     }
   ],
   "defaults": {


### PR DESCRIPTION
Enable benchmark scheduling for the newly added clinical-trial-simulation skill (PR #81). Sets priority to medium and schedule to on_change.

https://claude.ai/code/session_01QzovZzRcaxeC9jDLqkkNrC