### PR TITLE
[gsdbench-intake] Publish `_app/` to allow more static apps

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     paths:
-      - '_app/gsdbench-intake/**'
+      - '_app/**'
       - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
@@ -33,7 +33,7 @@ jobs:
       - name: Stage static app
         run: |
           mkdir -p _site
-          cp -R _app/gsdbench-intake/. _site/
+          cp -R _app/. _site/
 
       - name: Upload static artifact
         uses: actions/upload-pages-artifact@v5


### PR DESCRIPTION
This is follow up to #92, which somehow didn't include an important URL related change.

This PR further updated `.github/workflows/deploy-pages.yml`. The workflow now triggers on any change under `_app/**`, not only `_app/gsdbench-intake/**`. Also, it copies the entire `_app/` directory into `_site/` to allow publishing more future GitHub Pages content.

The intake form app will now be at: https://rconsortium.github.io/pharma-skills/gsdbench-intake/

Any new apps will be at: `https://rconsortium.github.io/pharma-skills/<app-name>/`.