### PR TITLE
[gsdbench-intake] Respect reduced motion and preserve intake governance metadata

### DIFF
--- a/_app/gsdbench-intake/assets/app.js
+++ b/_app/gsdbench-intake/assets/app.js
@@ -295,6 +295,7 @@
       submission_type: data.submission_type,
       created_from: data.created_from,
       contributor: {
+        name_or_initials: data.contributor.name_or_initials,
         github_username: data.contributor.github_username,
         role: data.contributor.role,
         organization_type: data.contributor.organization_type
@@ -302,7 +303,8 @@
       governance: {
         source_type: data.governance.source_type,
         no_phi_or_confidential_info_confirmed: data.governance.no_phi_or_confidential_info_confirmed,
-        permission_or_deidentification_confirmed: data.governance.permission_or_deidentification_confirmed
+        permission_or_deidentification_confirmed: data.governance.permission_or_deidentification_confirmed,
+        maintainer_revision_understood: data.governance.maintainer_revision_understood
       },
       benchmark_metadata: data.benchmark_metadata,
       task: data.task,
@@ -384,6 +386,7 @@
       `- [${data.governance.permission_or_deidentification_confirmed ? "x" : " "}] Permission to share publicly, or sufficiently generalized/de-identified.`,
       `- [${data.governance.maintainer_revision_understood ? "x" : " "}] Maintainers may request revisions before accepting this case.`,
       bullet("Source type", data.governance.source_type),
+      bullet("Contributor name or initials", data.contributor.name_or_initials),
       bullet("Contributor GitHub username", data.contributor.github_username),
       bullet("Contributor role", data.contributor.role),
       bullet("Organization type", data.contributor.organization_type)

--- a/_app/gsdbench-intake/assets/app.js
+++ b/_app/gsdbench-intake/assets/app.js
@@ -288,31 +288,7 @@
   }
 
   function buildIssueJson(data) {
-    return {
-      schema_version: data.schema_version,
-      case_id: data.case_id,
-      short_title: data.short_title,
-      submission_type: data.submission_type,
-      created_from: data.created_from,
-      contributor: {
-        name_or_initials: data.contributor.name_or_initials,
-        github_username: data.contributor.github_username,
-        role: data.contributor.role,
-        organization_type: data.contributor.organization_type
-      },
-      governance: {
-        source_type: data.governance.source_type,
-        no_phi_or_confidential_info_confirmed: data.governance.no_phi_or_confidential_info_confirmed,
-        permission_or_deidentification_confirmed: data.governance.permission_or_deidentification_confirmed,
-        maintainer_revision_understood: data.governance.maintainer_revision_understood
-      },
-      benchmark_metadata: data.benchmark_metadata,
-      task: data.task,
-      trial_design: data.trial_design,
-      reference_truth: data.reference_truth,
-      rubric: data.rubric,
-      review: data.review
-    };
+    return JSON.parse(JSON.stringify(data));
   }
 
   function generateIssueBody(data) {

--- a/_app/gsdbench-intake/assets/styles.css
+++ b/_app/gsdbench-intake/assets/styles.css
@@ -59,6 +59,12 @@ html {
   scroll-behavior: smooth;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
   margin: 0;
   background: var(--paper);


### PR DESCRIPTION
This is a follow-up to fix the Copilot code review comments in https://github.com/RConsortium/pharma-skills/pull/84.

This PR updates the GSDBench intake app to better preserve contributor and governance data in generated issue output.

Changes:

- Disable smooth scrolling when `prefers-reduced-motion: reduce` is set.
- Include `governance.maintainer_revision_understood` in exported JSON.
- Include optional contributor name/initials in both exported JSON and generated Markdown.

Also reviewed the JSON code-fence concern and left it unchanged because `JSON.stringify()` escapes user newlines, so user-entered backtick fences cannot prematurely close the generated JSON block.