### PR TITLE
[gsdbench-intake] Remove conflict markers from CSS

### DIFF
--- a/_app/gsdbench-intake/assets/styles.css
+++ b/_app/gsdbench-intake/assets/styles.css
@@ -81,19 +81,10 @@
   --radius: 8px;
   --radius-lg: 12px;
 
-<<<<<<< app-hero
-  --font-serif: "Source Serif 4", "Source Serif Pro", "Newsreader", "Iowan Old Style",
-    "Charter", Georgia, "Times New Roman", serif;
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue",
-    Arial, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas,
-    "Liberation Mono", monospace;
-  --page-max-width: 1480px;
-=======
   --font-serif: "Linden Hill", "Source Serif Pro", "Newsreader", "Iowan Old Style", "Charter", Georgia, "Times New Roman", serif;
   --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   --font-mono: "Liga Paper Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
->>>>>>> main
+  --page-max-width: 1480px;
 }
 
 * {


### PR DESCRIPTION
This PR removes the conflict markers created when merging https://github.com/RConsortium/pharma-skills/pull/96 so the CSS becomes valid and the serif font can be properly loaded.