### PR TITLE
[gsdbench-intake] Remove `font-feature-settings` from body styles

### DIFF
--- a/_app/gsdbench-intake/assets/styles.css
+++ b/_app/gsdbench-intake/assets/styles.css
@@ -108,7 +108,6 @@ body {
   font-family: var(--font-sans);
   font-size: 16px;
   line-height: 1.55;
-  font-feature-settings: "kern", "liga", "calt", "ss01";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
This PR removes the `font-feature-settings` from the GSDBench intake app CSS, so the sans-serif "a" glyph won't be displayed as the variant, among others.