### PR TITLE
fix(benchmark-runner): export CLAUDE_CODE_MAX_OUTPUT_TOKENS so claude inherits it

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -130,11 +130,14 @@ with open(os.path.join(agent_a_dir, "prompt_A.txt"), "w", encoding="utf-8") as f
 **Launch Agent A:**
 
 ```bash
+export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 cd /tmp/benchmark_{id}/agent_A && \
   cat prompt_A.txt | claude -p --model "{CURRENT_MODEL_NAME}" \
   --allowedTools "Bash,Read,Write,Edit,Glob" \
   --output-format json > agent_A_run.json 2>&1
 ```
+
+> **Note:** `export` is required — a prefix (`VAR=val cat ... | claude`) only sets the variable for `cat`, not for the `claude` process receiving the pipe.
 
 `--output-format json` emits a single JSON object when the agent finishes — resilient to long-running agents and session timeouts.
 
@@ -295,6 +298,7 @@ with open("/tmp/benchmark_{id}/agent_B/prompt_B.txt", "w") as f:
 Launch Agent B:
 
 ```bash
+export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
 cd /tmp/benchmark_{id}/agent_B && \
   cat prompt_B.txt | claude -p --model "{state['model']}" \
   --allowedTools "Bash,Read,Write,Edit,Glob" \


### PR DESCRIPTION
## Summary

The `Launch Agent A` / `Launch Agent B` blocks in `_automation/benchmark-runner/SKILL.md` set the output-token cap with a shell *prefix*:

```bash
CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000 cat prompt_A.txt | claude -p ...
```

In bash, `VAR=val cmd1 | cmd2` only sets `VAR` for `cmd1` (`cat`). The `claude` process on the right side of the pipe never sees the variable, so the default 32K output cap kicks in and the agent fails mid-response with:

```
API Error: Claude's response exceeded the 32000 output token maximum.
To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.
```

This bit me on a Phase 2 re-run for `github-issue-74` today — Agent A hit the 32K cap on its first launch despite the env var being set.

## Change

Use `export` so the variable lives in the shell and is inherited by every command in the pipeline:

```bash
export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
cd /tmp/benchmark_{id}/agent_A && \
  cat prompt_A.txt | claude -p ...
```

A short note was added below the Agent A block explaining the pitfall, so future readers don't reintroduce the prefix form.

The same fix is applied to the Step 6 (Agent B) launch block.

## Note on raising the cap further

The user asked whether we can go above 64K. **No** — 64K is the per-response output ceiling for `claude-sonnet-4-6` (and other current models); requests above that error out. The repo's `CLAUDE.md` already documents this:

> If you see `max_tokens` truncation, fix it by tightening [the one-artifact-per-turn rule], not by raising the cap further (64K is the model ceiling).

So the right way to handle persistent output-cap hits is to keep the agent producing one artifact per turn (already enforced by `group-sequential-design/SKILL.md`'s "Pacing" rule), not to raise the cap.

## Test plan

- [ ] Re-run Phase 2 for `github-issue-74` and confirm Agent A no longer hits the 32K cap
- [ ] Confirm Agent B's launch (Step 6) also runs to completion under the new export form

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYoRK4UHedbR7F8auvxEYR)_