### PR TITLE
Closes #89 Add admiral-adsl skill (initial files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-references/
 __pycache__/
 *.pyc
 *.pyo

--- a/admiral-adsl/DESIGN.md
+++ b/admiral-adsl/DESIGN.md
@@ -1,0 +1,243 @@
+# DESIGN.md — admiral-adsl
+
+This document records the design decisions, scope boundaries, and open questions
+for the `admiral-adsl` skill. It is a living document during the design phase —
+decisions will be updated as community input is received and benchmarks are
+developed.
+
+---
+
+## Skill Purpose
+
+Derive a CDISC-conformant ADaM Subject-Level Analysis Dataset (ADSL) using the
+{admiral} R package. The skill encodes the workflow, function selection logic,
+and CDISC conventions an experienced admiral programmer applies — enabling an
+AI coding agent to generate QC-ready, audit-traceable R code from SDTM inputs
+and an ADaM specification.
+
+---
+
+## Scope
+
+### In scope
+
+- Standard ADSL derivation for parallel-group and simple crossover studies
+- Single-period treatment variables following the TRT01P/TRT01A naming pattern
+- All required ADSL variables per ADaMIG v1.3
+- Common permissible variables: baseline demographics, disposition, standard
+  population flags (ENRLFL, RANDFL, SAFFL, ITTFL, FASFL, PPROTFL)
+- SDTM inputs following CDISC SDTMIG conventions
+- R implementation using admiral, dplyr, metacore, and xportr
+- Code structured for human QC review and regulatory submission
+
+### Out of scope (initial release)
+
+- Non-ADSL ADaM datasets — planned as follow-on skills
+- SAS implementation
+- Therapeutic-area-specific extensions (admiralonco, admiralvaccine,
+  admiralmetabolic)
+- Complex multi-period crossover designs (four or more periods)
+- Integrated analysis across multiple studies (IADSL)
+- Non-pharmaverse R implementations
+
+---
+
+## Key Design Decisions
+
+### Decision 1: Focused skill (admiral-adsl) rather than broad skill (admiral-adam)
+
+**Decision:** Build a focused `admiral-adsl` skill covering ADSL only, rather
+than a broad `admiral-adam` skill covering all ADaM dataset types.
+
+**Rationale:**
+- Consistent with the `group-sequential-design` precedent in this repo — focused
+  skills are more testable and have clearer benchmark criteria
+- ADSL has well-defined inputs (DM, EX, DS), predictable outputs, and universal
+  applicability across all studies — making it the strongest first candidate
+- Different ADaM dataset types (OCCDS, BDS, TTE) require substantially different
+  function patterns and conventions; a single skill would be too broad to encode
+  reliably
+- A focused skill establishes the pattern for a follow-on family
+  (admiral-adae, admiral-adtte, admiral-bds) without overpromising scope
+
+**Alternative considered:** A single `admiral-adam` skill with conditional logic
+by dataset type. Rejected because evaluation criteria would be difficult to
+define and the skill instructions would exceed manageable length.
+
+**Status:** Decided. Open to community input.
+
+---
+
+### Decision 2: pharmaversesdtm as the benchmark input source
+
+**Decision:** Use `{pharmaversesdtm}` SDTM datasets as the input source for all
+benchmarks, supplemented by synthetic modifications for edge case scenarios.
+
+**Rationale:**
+- pharmaversesdtm provides publicly available, CDISC-conformant SDTM data that
+  any contributor can access without restriction
+- Ensures benchmarks are fully reproducible across environments
+- Consistent with how the admiral package itself structures its test cases
+- pharmaverseadam provides reference ADaM outputs for correctness comparison
+
+**Alternative considered:** Synthetic SDTM data generated within each benchmark.
+Rejected as harder to maintain and less representative of real-world data.
+
+**Status:** Decided. Open to community suggestions for additional sources.
+
+---
+
+### Decision 3: Progressive disclosure structure for skill instructions
+
+**Decision:** Keep SKILL.md under 500 lines by offloading detailed function
+selection rationale to `references/admiral-functions.md` and CDISC variable
+conventions to `references/adsl-conventions.md`, loaded on demand.
+
+**Rationale:**
+- Follows the agentskills.io specification recommendation for progressive
+  disclosure
+- Prevents SKILL.md from becoming an unmanageable monolith as the skill matures
+- Allows reference files to be updated independently without modifying the core
+  skill instructions
+- Agents load reference files when the decision context requires them, reducing
+  token overhead for simple derivations
+
+**Status:** Decided.
+
+---
+
+### Decision 4: Human review annotations as a first-class output requirement
+
+**Decision:** The skill explicitly requires `# REVIEW:` comments at every
+protocol-specific decision point, treating these annotations as a required
+output dimension evaluated in benchmarks.
+
+**Rationale:**
+- Population flag definitions (SAFFL, ITTFL, PPROTFL), disposition record
+  selection, and age grouping cut-points are all study-specific. An agent that
+  silently applies default logic creates submission risk.
+- GxP context requires that AI-generated code is reviewable by a qualified
+  human before use. Explicit review flags support this requirement.
+- Makes the skill's outputs safer for use in regulated environments without
+  requiring the agent to refuse protocol-specific questions outright.
+
+**Status:** Decided.
+
+---
+
+### Decision 5: xportr + metacore for dataset attribute application
+
+**Decision:** Recommend `{xportr}` and `{metacore}` for applying variable
+labels, types, lengths, and order as the final step in ADSL derivation, rather
+than base R attribute functions.
+
+**Rationale:**
+- xportr is the pharmaverse standard for spec-driven XPT export
+- Ensures variable attributes are applied from the ADaM spec metadata, not
+  hardcoded in derivation code
+- Consistent with submission-ready pharmaverse workflows
+- `haven::write_xpt()` is noted as a simpler alternative for non-submission
+  contexts
+
+**Status:** Decided. Revisit if xportr interface changes significantly.
+
+---
+
+## Open Questions
+
+These questions are brought to the community for input before the skill is
+finalised.
+
+### OQ-1: Benchmark scope for population flags
+
+Population flag derivations (SAFFL, ITTFL, PPROTFL) are highly
+protocol-specific. Should benchmarks:
+
+a) Test only the standard logic (e.g. SAFFL = received at least one dose) and
+   explicitly mark PPROTFL as out of scope for automated evaluation?
+b) Include a benchmark with a defined protocol-specific PPROTFL rule to test
+   whether the agent correctly applies `# REVIEW:` annotations and defers?
+c) Both — a correctness benchmark for standard flags and a deferral benchmark
+   for complex ones?
+
+**Current inclination:** Option (c) — both types of benchmark provide different
+and complementary signal.
+
+---
+
+### OQ-2: admiral version pinning in benchmarks
+
+admiral has an active deprecation cycle (3-year window). Should benchmarks:
+
+a) Pin to a specific admiral version and update on a defined schedule?
+b) Test against the current CRAN release only?
+c) Test against both CRAN and the development version (main branch)?
+
+**Current inclination:** Option (b) for initial release, with a note in
+LIFECYCLE tracking that benchmark review should accompany major admiral releases.
+
+---
+
+### OQ-3: Evaluation of `# REVIEW:` annotation quality
+
+The rubric currently assesses whether `# REVIEW:` comments are present at
+expected locations. Should it also assess:
+
+a) Whether the comment text accurately describes what needs human review?
+b) Whether the agent correctly identifies *unexpected* protocol-specific
+   situations not covered by the skill instructions?
+
+**Current inclination:** (a) is in scope for v1 evaluation; (b) is aspirational
+and may be better addressed through adversarial benchmark design.
+
+---
+
+### OQ-4: Handling of DOMAIN variable conflicts
+
+The `derive_vars_merged()` function errors if a variable exists in both the
+input dataset and the source domain (e.g. DOMAIN). The skill currently
+instructs `select(domain, -DOMAIN)` as the fix. Should this be:
+
+a) Kept as an explicit instruction in SKILL.md (current approach)?
+b) Moved to `references/admiral-functions.md` under Common Pitfalls?
+c) Handled by a pre-processing step recommended in the workflow?
+
+**Current inclination:** Move to the pitfalls section of admiral-functions.md
+and add a pre-processing recommendation in the workflow.
+
+**Status:** Resolved. Pitfall #5 in `references/admiral-functions.md` covers the
+`-DOMAIN` pre-processing pattern. No changes needed to SKILL.md workflow.
+
+---
+
+## Planned Benchmarks
+
+| Benchmark | What it tests | Status |
+|---|---|---|
+| `basic-two-arm` | Standard parallel-group, complete data | In development |
+| `multi-arm` | Three treatment arms, TRT01P/TRT01A distinction | Planned |
+| `missing-dates` | Partial `--DTC` imputation in EX and DS | Planned |
+| `early-discontinuation` | EOSSTT/DCSREAS from DS, not all subjects complete | Planned |
+| `screen-failure` | Subjects in DM who never received treatment; SAFFL = NA | Planned |
+
+---
+
+## Planned Follow-On Skills
+
+This skill is intended as the first in a family of admiral ADaM derivation skills:
+
+| Skill | Dataset type | Depends on |
+|---|---|---|
+| `admiral-adsl` | Subject-level (this skill) | — |
+| `admiral-adae` | Occurrence (OCCDS) | admiral-adsl |
+| `admiral-adtte` | Time-to-event (BDS-TTE) | admiral-adsl |
+| `admiral-adex` | Exposure (BDS) | admiral-adsl |
+| `admiral-bds` | General BDS findings/efficacy | admiral-adsl |
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05 | Jeff Dickinson | Initial draft — design phase opened |

--- a/admiral-adsl/LICENSE
+++ b/admiral-adsl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jeff Dickinson, Navitas Data Sciences
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/admiral-adsl/README.md
+++ b/admiral-adsl/README.md
@@ -1,0 +1,162 @@
+# admiral-adsl
+
+An agent skill for deriving ADaM Subject-Level Analysis Datasets (ADSL) using
+the [{admiral}](https://pharmaverse.github.io/admiral/) R package and the
+pharmaverse ecosystem.
+
+## Overview
+
+ADSL is the foundational ADaM dataset required for every clinical study
+regulatory submission. It contains one record per subject and provides
+subject-level population flags, treatment variables, demographic information,
+disposition, and key dates that are merged into all other ADaM datasets.
+
+This skill encodes the workflow, function selection logic, and CDISC conventions
+that an experienced admiral programmer applies when building ADSL — enabling an
+AI coding agent to generate QC-ready, audit-traceable R code from SDTM inputs
+and an ADaM specification.
+
+## When to Use This Skill
+
+Use `admiral-adsl` when you need to:
+
+- Derive an ADSL dataset from SDTM domains using R and admiral
+- Generate standard subject-level variables (treatment dates, disposition
+  status, demographic groupings, population flags)
+- Produce code that is structured for human QC review and regulatory submission
+- Apply CDISC ADaM conventions correctly (flag values, date imputation, study
+  day calculation, dataset attributes)
+
+## Inputs Required
+
+| Input | Required | Description |
+|---|---|---|
+| DM | Yes | Subject spine — one record per USUBJID |
+| EX | Yes | Exposure — treatment dates and dose |
+| DS | Yes | Disposition — end of study status, reason for discontinuation |
+| MH | No | Medical history — if protocol-required flags needed |
+| VS | No | Vital signs — if HEIGHTBL, WEIGHTBL, BMIBL in scope |
+| ADaM ADSL spec | Yes | Variable list, derivation rules, grouping cut-points |
+| Study context | Yes | Treatment arm names, population flag definitions per SAP |
+
+## Outputs
+
+- Executable R code using admiral functions following pharmaverse idioms
+- Derivations for standard ADSL variables including treatment dates, planned
+  and actual treatment, disposition, baseline demographics, and population flags
+- `# REVIEW:` annotations at every protocol-specific decision point
+- Programmatic assertions (one record per USUBJID, required variables present)
+- Dataset and variable attribute application via `{xportr}` and `{metacore}`
+
+## Skill Files
+
+```
+admiral-adsl/
+├── SKILL.md                          # Core agent instructions and workflow
+├── DESIGN.md                         # Scope, constraints, design decisions
+├── README.md                         # This file
+├── references/
+│   ├── admiral-functions.md          # Function selection guide
+│   └── adsl-conventions.md           # CDISC variable and CT conventions
+├── benchmarks/
+│   ├── basic-two-arm/                # Simple parallel-group study
+│   ├── multi-arm/                    # Three or more treatment arms
+│   ├── missing-dates/                # Partial --DTC imputation
+│   ├── early-discontinuation/        # Subjects who did not complete
+│   └── screen-failure/               # Subjects who never received treatment
+└── LICENSE
+```
+
+## Dependencies
+
+```r
+# Core
+library(admiral)          # >= 1.2.0
+library(dplyr)
+library(lubridate)
+
+# Metadata and submission
+library(metacore)
+library(xportr)
+
+# Test data
+library(pharmaversesdtm)  # SDTM input datasets for benchmarks
+library(pharmaverseadam)  # Reference ADaM outputs for benchmarks
+```
+
+## Running Benchmarks
+
+Each benchmark directory contains:
+
+- `input/` — SDTM datasets (derived from `pharmaversesdtm` or study-specific)
+- `prompt.md` — The natural language prompt given to the agent
+- `expected/` — Expected output variables and values for evaluation
+- `rubric.md` — Scoring criteria for evaluating agent output
+
+To run a benchmark manually:
+
+1. Give the agent the contents of `prompt.md` and the SKILL.md
+2. Execute the generated R code against the input datasets
+3. Compare output against `expected/` using the criteria in `rubric.md`
+
+## Evaluation Criteria
+
+Agent output is evaluated against the following dimensions:
+
+| Dimension | What is assessed |
+|---|---|
+| **Correctness** | Key variable values match expected output (TRTSDT, TRTEDT, SAFFL, EOSSTT) |
+| **admiral idioms** | Correct function selection — `derive_vars_merged()` not `slice()`, `derive_vars_dy()` not manual subtraction |
+| **CDISC conformance** | Flag convention (`"Y"`/`NA` not `"N"`), date imputation direction, one record per USUBJID |
+| **QC readiness** | `# REVIEW:` comments at protocol-specific points, derivation comments, assertions present |
+| **Completeness** | Required variables present, dataset attributes applied |
+
+## Scope and Limitations
+
+**In scope:**
+- Standard ADSL derivation for parallel-group and simple crossover studies
+- Single-period treatment variables (TRT01P/TRT01A pattern)
+- SDTM inputs following CDISC SDTMIG conventions
+- R implementation using admiral
+
+**Out of scope:**
+- Non-ADSL ADaM datasets (see planned follow-on skills: `admiral-adae`,
+  `admiral-adtte`, `admiral-bds`)
+- SAS implementation
+- Therapeutic-area-specific extensions (`{admiralonco}`, `{admiralvaccine}`)
+- Highly complex crossover designs with four or more periods
+- Integrated analysis across multiple studies
+
+## Relationship to Other Skills
+
+This skill is the first in a planned family of admiral ADaM derivation skills:
+
+```
+admiral-adsl        ← this skill (subject-level foundation)
+admiral-adae        ← adverse events (OCCDS)
+admiral-adtte       ← time-to-event (BDS-TTE)
+admiral-adex        ← exposure (BDS)
+admiral-bds         ← general BDS (findings, efficacy)
+```
+
+ADSL must be derived before any other ADaM dataset, as population flags and
+treatment variables from ADSL are merged into all downstream datasets.
+
+## References
+
+- [admiral documentation](https://pharmaverse.github.io/admiral/)
+- [admiral ADSL vignette](https://pharmaverse.github.io/admiral/articles/adsl.html)
+- [CDISC ADaMIG v1.3](https://www.cdisc.org/standards/foundational/adam)
+- [pharmaverse examples — ADSL](https://pharmaverse.github.io/examples/)
+- [xportr documentation](https://atorus-research.github.io/xportr/)
+
+## Contributing
+
+Benchmark additions and refinements to SKILL.md are welcome. Please open an
+issue before submitting a PR to discuss the proposed change. See the repo-level
+[LIFECYCLE.md](../LIFECYCLE.md) for the skill development process.
+
+## Author
+
+Jeff Dickinson, Navitas Data Sciences  
+Admiral Core Team member

--- a/admiral-adsl/SKILL.md
+++ b/admiral-adsl/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: admiral-adsl
+description: >
+  Derives an ADaM Subject-Level Analysis Dataset (ADSL) using the {admiral}
+  R package and pharmaverse ecosystem. Use when a user needs to create ADSL
+  from SDTM domains, derive standard subject-level variables (treatment dates,
+  disposition, demographics, population flags), or generate QC-ready R code
+  following CDISC ADaM conventions. Requires SDTM input data and an ADaM spec.
+license: MIT
+metadata:
+  author: Navitas Data Sciences
+  version: "0.1"
+  pharmaverse: "true"
+compatibility: >
+  Requires R with admiral, dplyr, lubridate, and pharmaversesdtm installed.
+  Designed for use in a GxP-compliant environment with access to SDTM datasets
+  and an ADaM ADSL specification.
+---
+
+# admiral-adsl
+
+Derives a CDISC-conformant ADSL dataset using {admiral}. Outputs executable,
+QC-ready R code with derivation logic traceable to the ADaM specification.
+
+See [admiral-functions reference](references/admiral-functions.md) for function
+selection guidance. See [adsl-conventions reference](references/adsl-conventions.md)
+for CDISC variable conventions.
+
+---
+
+## Inputs
+
+Before generating code, confirm the following are available or explicitly noted
+as absent:
+
+| Input | Required | Notes |
+|---|---|---|
+| DM | Yes | Subject spine; one record per USUBJID |
+| EX | Yes | Exposure; needed for treatment dates and SAFFL |
+| DS | Yes | Disposition; needed for EOSSTT, DCSREAS |
+| MH | No | Medical history flags if protocol requires |
+| VS | No | HEIGHTBL, WEIGHTBL, BMIBL if in scope |
+| ADaM ADSL spec | Yes | Variable list, derivation rules, grouping cut-points |
+| Study context | Yes | Treatment arm names, population flag definitions |
+
+If required domains are absent, stop and request them. If optional domains are
+absent, omit the corresponding derivations and note this in code comments.
+
+---
+
+## Workflow
+
+Follow these steps in order. Generate code section by section, not as a single
+block.
+
+### Step 1 — Setup and domain loading
+
+```r
+library(admiral)
+library(dplyr)
+library(lubridate)
+
+# Load SDTM domains
+dm  <- pharmaversesdtm::dm
+ex  <- pharmaversesdtm::ex
+ds  <- pharmaversesdtm::ds
+# mh <- pharmaversesdtm::mh  # uncomment if in scope
+```
+
+### Step 2 — Subject spine
+
+Start from DM. One record per USUBJID is mandatory at this step and must be
+preserved throughout.
+
+```r
+adsl <- dm |>
+  select(STUDYID, USUBJID, SUBJID, SITEID, AGE, AGEU, SEX, RACE, ETHNIC,
+         COUNTRY, ARM, ARMCD, ACTARM, ACTARMCD, DMDTC, RFSTDTC, RFENDTC)
+```
+
+Only select variables needed downstream. Do not carry all of DM forward.
+
+### Step 3 — Treatment dates (TRTSDT, TRTEDT)
+
+Derive from EX. TRTSDT = first dose date; TRTEDT = last dose date per subject.
+Use `derive_vars_merged()` with `order` and `mode` — do not use `slice()` or
+manual `group_by/summarise` approaches as these lose admiral traceability.
+
+```r
+ex_dt <- ex |>
+  derive_vars_dtm(
+    dtc = EXSTDTC,
+    new_vars_prefix = "EXST",
+    date_imputation = "first",
+    flag_imputation = "auto"
+  ) |>
+  derive_vars_dtm(
+    dtc = EXENDTC,
+    new_vars_prefix = "EXEN",
+    date_imputation = "last",
+    flag_imputation = "auto"
+  )
+
+adsl <- adsl |>
+  derive_vars_merged(
+    dataset_add = ex_dt,
+    by_vars = exprs(STUDYID, USUBJID),
+    new_vars = exprs(TRTSDTM = EXSTDTM),
+    order = exprs(EXSTDTM),
+    mode = "first",
+    filter_add = !is.na(EXSTDTM)
+  ) |>
+  derive_vars_merged(
+    dataset_add = ex_dt,
+    by_vars = exprs(STUDYID, USUBJID),
+    new_vars = exprs(TRTEDTM = EXENDTM),
+    order = exprs(EXENDTM),
+    mode = "last",
+    filter_add = !is.na(EXENDTM)
+  ) |>
+  mutate(
+    TRTSDT = as.Date(TRTSDTM),
+    TRTEDT = as.Date(TRTEDTM)
+  )
+```
+
+**Flag for human review:** If subjects have gaps in exposure (multiple EX
+records with non-contiguous dates), TRTEDT may not reflect the true end of
+treatment. Add a comment and flag for QC.
+
+### Step 4 — Planned and actual treatment (TRT01P, TRT01A)
+
+TRT01P comes from DM.ARM (randomised treatment). TRT01A comes from EX
+(actual treatment received). These are distinct and must not be conflated.
+
+```r
+adsl <- adsl |>
+  mutate(
+    TRT01P  = ARM,
+    TRT01A  = ACTARM,
+    TRT01CD = ARMCD,
+    TRT01CA = ACTARMCD
+  )
+```
+
+If the study has multiple periods, derive TRT02P/TRT02A etc. from EX using
+period-specific filtering. Note this in code comments if applicable.
+
+### Step 5 — Randomisation and reference dates
+
+```r
+adsl <- adsl |>
+  derive_vars_dt(
+    dtc = RFSTDTC,
+    new_vars_prefix = "RFST"
+  ) |>
+  derive_vars_dt(
+    dtc = RFENDTC,
+    new_vars_prefix = "RFEND"
+  ) |>
+  mutate(RANDDT = as.Date(DMDTC))
+```
+
+### Step 6 — Study day variables
+
+Use `derive_vars_dy()` — do not compute manually with date subtraction.
+
+```r
+adsl <- adsl |>
+  derive_vars_dy(
+    reference_date = TRTSDT,
+    source_vars = exprs(RANDDT)
+  )
+```
+
+### Step 7 — Disposition (EOSSTT, DCSREAS, DCSREASP)
+
+Filter DS to `DSCAT == "DISPOSITION EVENT"`. If multiple records exist per
+subject, select the primary disposition record per protocol. This is a common
+source of error — check the protocol definition and add a comment.
+
+```r
+ds_eos <- ds |>
+  filter(DSCAT == "DISPOSITION EVENT") |>
+  derive_vars_dt(
+    dtc = DSDTC,
+    new_vars_prefix = "DS"
+  )
+
+adsl <- adsl |>
+  derive_vars_disposition_status(
+    dataset_ds    = ds_eos,
+    new_var       = EOSSTT,
+    status_var    = DSDECOD,
+    filter_ds     = DSCAT == "DISPOSITION EVENT"
+    # REVIEW: verify EOSSTT values match protocol-defined categories (e.g. "COMPLETED", "DISCONTINUED")
+    # If the built-in formatter does not fit, swap to derive_vars_merged() with manual new_vars.
+  ) |>
+  derive_vars_merged(
+    dataset_add = ds_eos,
+    by_vars = exprs(STUDYID, USUBJID),
+    new_vars = exprs(DCSREAS = DSDECOD, DCSREASP = DSTERM, EOSDT = DSDT),
+    order = exprs(DSDT),
+    mode = "last"
+  )
+```
+
+**Protocol-specific note:** EOSSTT values (e.g. "COMPLETED", "DISCONTINUED")
+must match the protocol-defined categories. Review with the statistician before
+finalising.
+
+### Step 8 — Baseline demographics
+
+Derive AGE groupings and other categorisations per the ADaM spec. The cut
+points for AGEGR1 must come from the spec — do not assume standard cut points.
+
+```r
+adsl <- adsl |>
+  mutate(
+    # Replace cut points with those defined in the ADaM spec
+    AGEGR1 = case_when(
+      AGE < 18             ~ "<18",
+      AGE >= 18 & AGE < 65 ~ "18-<65",
+      AGE >= 65            ~ ">=65"
+    ),
+    AGEGR1N = case_when(
+      AGEGR1 == "<18"   ~ 1,
+      AGEGR1 == "18-<65"~ 2,
+      AGEGR1 == ">=65"  ~ 3
+    )
+  )
+```
+
+If VS is in scope, derive HEIGHTBL, WEIGHTBL, BMIBL using
+`derive_vars_merged()` from the baseline VS records (VSBLFL == "Y").
+
+### Step 9 — Population flags (SAFFL, ITTFL, PPROTFL, ENRLFL)
+
+**Critical:** population flag definitions are protocol-specific. The derivations
+below implement standard logic but must be reviewed against the protocol and SAP
+before use.
+
+```r
+adsl <- adsl |>
+  # SAFFL: received at least one dose
+  derive_var_merged_exist_flag(
+    dataset_add = ex,
+    by_vars = exprs(STUDYID, USUBJID),
+    new_var = SAFFL,
+    condition = !is.na(EXSTDTC)
+  ) |>
+  # ITTFL: randomised (in DM with ARM assigned)
+  mutate(
+    ITTFL = if_else(!is.na(ARM) & ARM != "Screen Failure", "Y", NA_character_)
+  ) |>
+  # ENRLFL: enrolled (all subjects in DM)
+  mutate(ENRLFL = "Y")
+  # PPROTFL: per protocol — highly protocol-specific, derive per SAP definition
+```
+
+**Flag for human review:** PPROTFL derivation requires protocol-specific
+exclusion criteria (e.g. major protocol deviations). Insert a placeholder and
+require statistician input.
+
+### Step 10 — Dataset attributes and final checks
+
+```r
+# Verify one record per USUBJID
+stopifnot(nrow(adsl) == n_distinct(adsl$USUBJID))
+
+# Check required variables are present
+required_vars <- c("STUDYID", "USUBJID", "TRTSDT", "TRTEDT",
+                   "TRT01P", "TRT01A", "EOSSTT", "SAFFL", "ITTFL")
+missing_vars <- setdiff(required_vars, names(adsl))
+if (length(missing_vars) > 0) {
+  stop("Missing required ADSL variables: ", paste(missing_vars, collapse = ", "))
+}
+
+# Apply dataset and variable attributes from the ADaM spec (xportr recommended for submission)
+# Replace metacore_obj with your loaded metacore object derived from the ADaM spec.
+# adsl <- adsl |>
+#   xportr_label(metacore_obj, domain = "ADSL") |>
+#   xportr_type(metacore_obj, domain = "ADSL") |>
+#   xportr_length(metacore_obj, domain = "ADSL") |>
+#   xportr_order(metacore_obj, domain = "ADSL")
+# xportr_write(adsl, "adsl.xpt", label = "Subject-Level Analysis Dataset")
+#
+# For non-submission contexts, apply labels directly:
+# Hmisc::label(adsl$TRTSDT) <- "Date of First Study Treatment"
+# Hmisc::label(adsl$SAFFL)  <- "Safety Population Flag"
+```
+
+Apply variable labels using `Hmisc::label()` or `haven::write_xpt()` attributes
+per the ADaM spec metadata. Dataset label should be "Subject-Level Analysis Dataset".
+
+---
+
+## Code quality requirements
+
+Generated code must meet these standards for QC-readiness:
+
+- **Comments:** Each derivation block must have a comment referencing the source
+  variable (e.g. `# TRTSDT: first dose date from EX.EXSTDTC per ADaM spec §4.2`)
+- **Human review flags:** Use `# REVIEW:` comments where protocol-specific
+  decisions are required (population flags, disposition record selection, cut points)
+- **No silent failures:** Use `stopifnot()` or `cli::cli_abort()` for critical
+  assertions (one record per subject, required variables present)
+- **Pipe style:** Use the native pipe `|>` and `exprs()` for admiral verb arguments
+- **No manual date arithmetic:** Always use admiral date derivation functions
+
+---
+
+## Common errors to avoid
+
+- Using `slice(1)` or manual `group_by/summarise` instead of `derive_vars_merged()` with `mode`
+- Setting `date_imputation = "none"` when partial dates are present in SDTM
+- Conflating TRT01P (planned, from DM.ARM) with TRT01A (actual, from EX)
+- Assuming DS has one record per subject — always filter to the correct DSCAT
+- Using `"N"` for flag variables — CDISC convention is `"Y"` or `NA`, never `"N"`
+- Hardcoding AGEGR1 cut points — always take these from the ADaM spec
+
+---
+
+## Output checklist
+
+Before returning code, verify:
+
+- [ ] One record per USUBJID confirmed with `stopifnot()`
+- [ ] All required variables present
+- [ ] All `# REVIEW:` comments placed at protocol-specific decision points
+- [ ] Date imputation arguments explicitly set (not left as defaults)
+- [ ] Population flag derivations annotated with protocol reference
+- [ ] Dataset and variable labels applied

--- a/admiral-adsl/benchmarks/README.md
+++ b/admiral-adsl/benchmarks/README.md
@@ -1,0 +1,38 @@
+# Benchmarks
+
+Each subdirectory contains one benchmark scenario for the `admiral-adsl` skill.
+
+## Structure
+
+Every benchmark follows this layout:
+
+```
+{benchmark-name}/
+├── prompt.md       # Natural language prompt given to the agent
+├── rubric.md       # Scoring criteria for evaluating agent output
+├── input/          # SDTM input datasets (R scripts to generate from pharmaversesdtm)
+└── expected/       # Expected output variables and values for correctness checks
+```
+
+## Planned Benchmarks
+
+| Benchmark | What it tests | Status |
+|---|---|---|
+| `basic-two-arm` | Standard parallel-group study, complete data, all required ADSL variables | Planned |
+| `multi-arm` | Three treatment arms, TRT01P/TRT01A distinction, numeric companion variables | Planned |
+| `missing-dates` | Partial `--DTC` imputation in EX and DS; correct use of `date_imputation` | Planned |
+| `early-discontinuation` | EOSSTT/DCSREAS derivation; subjects who did not complete the study | Planned |
+| `screen-failure` | Subjects in DM who never received treatment; SAFFL = NA, not "N" | Planned |
+
+## Running a Benchmark Manually
+
+1. Give the agent the contents of `prompt.md` and `SKILL.md`
+2. Execute the generated R code against the input datasets in `input/`
+3. Score the output against `expected/` using the criteria in `rubric.md`
+
+## Input Data
+
+Inputs are generated from [`{pharmaversesdtm}`](https://pharmaverse.github.io/pharmaversesdtm/)
+and [`{pharmaverseadam}`](https://pharmaverse.github.io/pharmaverseadam/) — publicly available,
+CDISC-conformant datasets that any contributor can reproduce. Study-specific modifications
+for edge case scenarios are applied within the `input/` scripts.

--- a/admiral-adsl/references/admiral-functions.md
+++ b/admiral-adsl/references/admiral-functions.md
@@ -1,0 +1,416 @@
+# admiral Function Reference for ADSL
+
+This reference covers the admiral functions most relevant to ADSL derivation.
+It is structured around **decision guidance** — which function to use in a given
+situation and why — not as a comprehensive API reference. For full signatures
+and examples see the [admiral documentation](https://pharmaverse.github.io/admiral/).
+
+---
+
+## The Core Decision Framework
+
+admiral's generic derivation functions follow three properties:
+
+| Property | What it means | Functions |
+|---|---|---|
+| **Selection** | Select records (e.g. first dose, baseline) | `derive_vars_merged()`, `derive_vars_joined()` |
+| **Summary** | Summarise values (e.g. count, concatenate) | `derive_var_merged_summary()` |
+| **Computation** | Compute from multiple values (e.g. BMI) | `derive_vars_computed()` |
+
+For ADSL, **selection** is the dominant pattern. Almost every derivation involves
+selecting a specific record from a source domain and merging variables across.
+
+---
+
+## Function Selection Guide
+
+### `derive_vars_merged()` — the workhorse
+
+Use when:
+- Merging variables from another domain where the selection logic depends **only
+  on the source dataset** (not on variables in both datasets simultaneously)
+- Selecting first or last record per subject (with `order` + `mode`)
+- Checking for the existence of a record (with `exist_flag`)
+- Handling one-to-one or many-to-one relationships from source to ADSL
+
+**Signature (key arguments):**
+```r
+derive_vars_merged(
+  dataset,                 # ADSL being built
+  dataset_add,             # source domain (EX, DS, VS, etc.)
+  by_vars   = exprs(...),  # join keys, e.g. exprs(STUDYID, USUBJID)
+  new_vars  = exprs(...),  # variables to bring across, with optional rename
+  order     = exprs(...),  # sort order for record selection
+  mode      = "first"      # "first" or "last" — which record to take
+  filter_add = ...,        # filter applied to dataset_add before selection
+  missing_values = list(), # values to use when no match found
+  check_type = "warning"   # "warning", "error", or "none" for duplicate handling
+)
+```
+
+**ADSL examples:**
+
+```r
+# TRTSDT: first non-zero dose date per subject
+adsl <- adsl |>
+  derive_vars_merged(
+    dataset_add = ex_dt,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_vars    = exprs(TRTSDT = EXSTDT),
+    order       = exprs(EXSTDT),
+    mode        = "first",
+    filter_add  = EXDOSE > 0 & !is.na(EXSTDT)
+  )
+
+# TRTEDT: last non-zero dose date per subject
+adsl <- adsl |>
+  derive_vars_merged(
+    dataset_add = ex_dt,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_vars    = exprs(TRTEDT = EXENDT),
+    order       = exprs(EXENDT),
+    mode        = "last",
+    filter_add  = EXDOSE > 0 & !is.na(EXENDT)
+  )
+
+# HEIGHTBL: baseline height from VS
+adsl <- adsl |>
+  derive_vars_merged(
+    dataset_add = vs,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_vars    = exprs(HEIGHTBL = VSSTRESN),
+    filter_add  = VSTESTCD == "HEIGHT" & VSBLFL == "Y"
+  )
+```
+
+**Do NOT use `derive_vars_merged()` when:**
+- The record selection condition references variables from **both** the input
+  dataset and the source dataset simultaneously — use `derive_vars_joined()` instead
+- Example of the wrong pattern: assigning period variables to ADAE where you need
+  to compare AESTDT against ADSL period start/end dates
+
+---
+
+### `derive_vars_joined()` — when both datasets inform selection
+
+Use when:
+- The filter or selection condition involves variables from **both** the input
+  dataset and the additional dataset at the same time (`filter_join` argument)
+- Typical ADSL use cases are rare; more common in ADAE, ADEX, BDS datasets
+- In ADSL context: selecting a DS record where the date must fall within a
+  window defined by ADSL variables
+
+**Key difference from `derive_vars_merged()`:**
+
+```r
+# derive_vars_merged: filter applies only to dataset_add
+filter_add = EXDOSE > 0              # only looks at EX variables
+
+# derive_vars_joined: filter_join can reference both datasets
+filter_join = EXSTDT <= ASTDT        # ASTDT is from the input dataset (ADAE)
+                                     # EXSTDT is from the source (EX)
+```
+
+**When you see yourself doing a merge then a filter on the result**, that is a
+signal to use `derive_vars_joined()` instead.
+
+---
+
+### `derive_var_merged_exist_flag()` — existence flags
+
+Use when:
+- Adding a flag (`"Y"` / `NA`) indicating whether a subject has **at least one**
+  record meeting a condition in another domain
+- Standard pattern for SAFFL, and for any flag driven by presence/absence
+
+```r
+# SAFFL: received at least one dose
+adsl <- adsl |>
+  derive_var_merged_exist_flag(
+    dataset_add = ex,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_var     = SAFFL,
+    condition   = EXDOSE > 0 & !is.na(EXSTDTC),
+    true_value  = "Y",
+    false_value = NA_character_,   # CDISC: never "N"
+    missing_value = NA_character_  # subjects absent from EX get NA
+  )
+```
+
+Note: `derive_var_merged_exist_flag()` is a convenience wrapper around
+`derive_vars_merged()`. For flags driven by **multiple source domains** (e.g. a
+flag that is `"Y"` if a record exists in CM **or** PR), use the more powerful
+`derive_var_merged_ef_msrc()` instead.
+
+---
+
+### `derive_var_merged_ef_msrc()` — existence flags from multiple sources
+
+Use when:
+- A flag is `"Y"` if a condition is met in **any** of several source datasets
+- Common for prior therapy flags, comorbidity flags spanning multiple domains
+
+```r
+# ANYTRTFL: received any anti-cancer treatment (CM or PR)
+adsl <- adsl |>
+  derive_var_merged_ef_msrc(
+    by_vars    = exprs(STUDYID, USUBJID),
+    new_var    = ANYTRTFL,
+    flag_events = list(
+      flag_event(dataset_name = "cm", condition = CMCAT == "ANTI-CANCER"),
+      flag_event(dataset_name = "pr")   # all PR records count
+    ),
+    source_datasets = list(cm = cm, pr = pr)
+  )
+```
+
+---
+
+### `derive_vars_dt()` — date derivation from `--DTC`
+
+Use when:
+- Converting an SDTM character date (`--DTC`) to a SAS/R Date variable
+- Need to handle partial dates with imputation
+
+```r
+ds_dt <- ds |>
+  derive_vars_dt(
+    dtc              = DSDTC,
+    new_vars_prefix  = "DS",          # creates DSDT and DSDTF
+    date_imputation  = "last",        # "first", "last", "mid", or "none"
+    flag_imputation  = "auto"         # auto-creates imputation flag
+  )
+```
+
+**Never** use `as.Date()` directly on `--DTC` variables. It will silently return
+`NA` for partial dates (e.g. `"2023-06"`) without any warning.
+
+**Imputation rules for ADSL:**
+- Start date variables (TRTSDT, RANDDT): `date_imputation = "first"`
+- End date variables (TRTEDT, EOSDT): `date_imputation = "last"`
+- Reference dates from DM (RFSTDTC, RFENDTC): follow the protocol definition
+
+---
+
+### `derive_vars_dtm()` — datetime derivation from `--DTC`
+
+Use when:
+- The source variable contains datetime information (`--DTC` with time component)
+- Creating TRTSTM / TRTENDTM before deriving date-only variables
+
+```r
+ex_dtm <- ex |>
+  derive_vars_dtm(
+    dtc              = EXSTDTC,
+    new_vars_prefix  = "EXST",
+    date_imputation  = "first",
+    time_imputation  = "first",     # "first" = 00:00:00, "last" = 23:59:59
+    flag_imputation  = "auto"
+  )
+```
+
+For ADSL, derive the datetime first, then extract the date:
+```r
+adsl <- adsl |>
+  mutate(TRTSDT = as.Date(TRTSTM))
+```
+
+---
+
+### `derive_vars_dy()` — study day calculation
+
+Use when:
+- Computing `--DY` variables (study day relative to a reference date)
+- **Always use this function** — never compute manually with date subtraction
+
+```r
+adsl <- adsl |>
+  derive_vars_dy(
+    reference_date = TRTSDT,
+    source_vars    = exprs(RANDDT, EOSDT)
+    # creates RANDDY and EOSDY automatically
+  )
+```
+
+CDISC study day convention: day 1 is the reference date; there is no day 0.
+This function handles that correctly. Manual subtraction (`date2 - date1`) does not.
+
+---
+
+### `derive_var_trtdurd()` — treatment duration
+
+Use when:
+- Deriving TRTDURD (total treatment duration in days)
+
+```r
+adsl <- adsl |>
+  derive_var_trtdurd()
+  # Requires TRTSDT and TRTEDT to already be present
+```
+
+---
+
+### `derive_vars_disposition_status()` — disposition variables
+
+Use when:
+- Deriving EOSSTT (end of study status) from DS
+- Handles multiple DS records per subject and category filtering
+
+```r
+adsl <- adsl |>
+  derive_vars_disposition_status(
+    dataset_ds      = ds_dt,
+    new_var         = EOSSTT,
+    status_var      = DSSCAT,
+    filter_ds       = DSCAT == "DISPOSITION EVENT",
+    format_new_var  = format_eossttu   # built-in formatter
+  )
+```
+
+If your study's DS structure does not map cleanly to the built-in formatter,
+fall back to `derive_vars_merged()` with explicit `filter_add` and manual
+`new_vars` specification. Add a `# REVIEW:` comment explaining the deviation.
+
+---
+
+### `derive_vars_merged_lookup()` — controlled terminology mapping
+
+Use when:
+- Mapping a coded value to a decode using a lookup table
+- Applying CDISC CT or study-specific controlled terminology
+
+```r
+# Example: mapping ARMCD to numeric treatment code
+arm_lookup <- tibble::tribble(
+  ~ARMCD,  ~TRT01PN,
+  "A",     1,
+  "B",     2,
+  "P",     99
+)
+
+adsl <- adsl |>
+  derive_vars_merged_lookup(
+    dataset_add = arm_lookup,
+    by_vars     = exprs(ARMCD),
+    new_vars    = exprs(TRT01PN)
+  )
+```
+
+---
+
+### `derive_vars_cat()` — categorisation variables
+
+Use when:
+- Deriving `--CAT` variables (e.g. AGEGR1, BMI category) from a definition table
+- Preferred over `case_when()` for any categorisation that will be reused or
+  needs to be spec-driven
+
+```r
+# Age grouping from a definition tibble
+agegr1_lookup <- exprs(
+  ~condition,       ~AGEGR1,   ~AGEGR1N,
+  AGE < 18,         "<18",     1,
+  AGE < 65,         "18-<65",  2,
+  TRUE,             ">=65",    3
+)
+
+adsl <- adsl |>
+  derive_vars_cat(
+    definition = agegr1_lookup,
+    by_vars    = exprs(AGE)
+  )
+```
+
+Cut points **must** come from the ADaM specification. Do not hardcode.
+
+---
+
+## Common Pitfalls
+
+### 1. Using `slice()` instead of `derive_vars_merged()` with `mode`
+
+```r
+# WRONG — loses admiral traceability, fragile to sort order
+ex |>
+  group_by(USUBJID) |>
+  slice(1) |>
+  select(USUBJID, EXSTDT) |>
+  left_join(adsl, by = "USUBJID")
+
+# CORRECT
+adsl |>
+  derive_vars_merged(
+    dataset_add = ex,
+    by_vars     = exprs(USUBJID),
+    new_vars    = exprs(TRTSDT = EXSTDT),
+    order       = exprs(EXSTDT),
+    mode        = "first",
+    filter_add  = EXDOSE > 0
+  )
+```
+
+### 2. Using `"N"` for flag variables
+
+```r
+# WRONG — violates CDISC ADaM convention
+mutate(SAFFL = if_else(has_dose, "Y", "N"))
+
+# CORRECT — "Y" or NA only
+mutate(SAFFL = if_else(has_dose, "Y", NA_character_))
+```
+
+### 3. Forgetting `filter_add = EXDOSE > 0` for treatment dates
+
+Subjects may have zero-dose EX records (e.g. dose not given, dose omitted).
+TRTSDT must reflect actual drug exposure. Always filter `EXDOSE > 0` (or the
+protocol-equivalent condition) when deriving treatment start/end dates.
+
+### 4. Conflating TRT01P and TRT01A
+
+| Variable | Source | Meaning |
+|---|---|---|
+| TRT01P / TRT01PA | DM.ARM / DM.ACTARM | Planned treatment (randomisation) |
+| TRT01A | EX | Actual treatment received |
+
+These are different. In most studies they match, but they diverge for subjects
+who receive wrong treatment or cross over. Derive them independently.
+
+### 5. Missing `DOMAIN` variable conflicts in `derive_vars_merged()`
+
+If the source domain retains its `DOMAIN` variable and ADSL also has `DOMAIN`,
+admiral will error. Remove it from the source before merging:
+
+```r
+adsl |>
+  derive_vars_merged(
+    dataset_add = select(ex, -DOMAIN),
+    ...
+  )
+```
+
+### 6. Not setting `check_type`
+
+By default `check_type = "warning"` — duplicate by-group records in `dataset_add`
+produce a warning but proceed. For ADSL derivations this should usually be
+`"error"` when you expect one record per subject, or ensure `filter_add` + `order`
++ `mode` guarantee uniqueness before the merge.
+
+---
+
+## Quick Reference Card
+
+| Situation | Function |
+|---|---|
+| Merge value from another domain (one record per subject) | `derive_vars_merged()` |
+| Select first/last record per subject | `derive_vars_merged()` with `order` + `mode` |
+| Selection depends on variables in both datasets | `derive_vars_joined()` |
+| Flag: subject has ≥1 record meeting condition (single source) | `derive_var_merged_exist_flag()` |
+| Flag: subject has ≥1 record meeting condition (multiple sources) | `derive_var_merged_ef_msrc()` |
+| Convert `--DTC` to Date | `derive_vars_dt()` |
+| Convert `--DTC` to Datetime | `derive_vars_dtm()` |
+| Study day calculation | `derive_vars_dy()` |
+| Treatment duration | `derive_var_trtdurd()` |
+| Disposition status from DS | `derive_vars_disposition_status()` |
+| Controlled terminology mapping | `derive_vars_merged_lookup()` |
+| Categorisation variables (AGEGR1 etc.) | `derive_vars_cat()` |
+| Numeric summary (count, sum) | `derive_var_merged_summary()` |

--- a/admiral-adsl/references/adsl-conventions.md
+++ b/admiral-adsl/references/adsl-conventions.md
@@ -1,0 +1,403 @@
+# ADSL Conventions Reference
+
+CDISC ADaM conventions for ADSL dataset construction. This reference covers
+variable requirements, naming rules, controlled terminology, flag conventions,
+dataset attributes, and define.xml metadata expectations. It is intended as a
+compact, programming-facing reference — not a substitute for the ADaMIG v1.3.
+
+---
+
+## Structure Rule: One Record Per Subject
+
+ADSL contains one record per subject. This is
+non-negotiable and must be verified programmatically before delivery:
+
+```r
+stopifnot(nrow(adsl) == n_distinct(adsl$USUBJID))
+```
+
+The FDA has explicitly refused ADSL structures with more than one record per
+unique subject. Any multi-period or integrated analysis requirements must be
+handled through additional datasets (ADPL, period-specific BDS variables), not
+by adding rows to ADSL.
+
+---
+
+## Required Variables
+
+Required variables that must be included in every ADSL — all can be taken
+directly from the DM dataset:
+
+| Variable | Type | Source | Notes |
+|---|---|---|---|
+| STUDYID | Char | DM | Study identifier |
+| USUBJID | Char | DM | Unique subject identifier — primary key |
+| SUBJID | Char | DM | Subject identifier within site |
+| SITEID | Char | DM | Study site identifier |
+| AGE | Num | DM | Age at study entry |
+| AGEU | Char | DM | Age units — usually `"YEARS"` |
+| SEX | Char | DM | CDISC CT: `"M"`, `"F"`, `"U"`, `"UNDIFFERENTIATED"` |
+| RACE | Char | DM | CDISC CT — see Race CT section below |
+
+When carrying SDTM variables into ADSL without modification, the variable name
+**and all attributes** (label, format, length) must be preserved unchanged.
+
+---
+
+## Conditionally Required Variables
+
+These variables are required when the concept applies to the study:
+
+| Variable | Required when | Notes |
+|---|---|---|
+| TRT01P | Randomised study | Planned treatment period 1 |
+| TRT01A | Randomised study | Actual treatment period 1 |
+| TRTSDT | Subject received treatment | First treatment start date |
+| TRTEDT | Subject received treatment | Last treatment end date |
+| RANDDT | Randomised study | Date of randomisation |
+| DTHFL | Death is an endpoint or safety concern | Death flag |
+| DTHDT | DTHFL = "Y" | Date of death |
+
+For multi-period studies, period-specific variables (TRT02P, TRT02A, TR02SDT,
+TR02EDT, etc.) follow the same pattern with incrementing period numbers.
+
+---
+
+## Common Permissible Variables
+
+These are not required by CDISC but are expected in most submissions:
+
+**Demographics and baseline:**
+
+| Variable | Type | Derivation source | Notes |
+|---|---|---|---|
+| ETHNIC | Char | DM | CDISC CT |
+| COUNTRY | Char | DM | ISO 3166 alpha-3 |
+| BRTHDTC | Char | DM | Birth date character |
+| AGEGR1 | Char | Derived from AGE | Cut points from ADaM spec |
+| AGEGR1N | Num | Derived from AGEGR1 | Numeric version |
+| HEIGHTBL | Num | VS (VSBLFL="Y") | Baseline height |
+| WEIGHTBL | Num | VS (VSBLFL="Y") | Baseline weight |
+| BMIBL | Num | Derived | kg/m² — use `derive_vars_computed()` |
+| RACE1 | Char | DM or suppDM | For multi-race capture |
+
+**Treatment:**
+
+| Variable | Type | Source | Notes |
+|---|---|---|---|
+| TRT01PN | Num | Derived | Numeric code for TRT01P |
+| TRT01AN | Num | Derived | Numeric code for TRT01A |
+| TRTSEQP | Char | DM.ARMCD | Planned treatment sequence (crossover) |
+| TRTSEQA | Char | EX | Actual treatment sequence (crossover) |
+| TRTDURD | Num | Derived | Total treatment duration (days) |
+
+**Disposition:**
+
+| Variable | Type | Source | Notes |
+|---|---|---|---|
+| EOSSTT | Char | DS | End of study status |
+| DCSREAS | Char | DS | Reason for discontinuation (decoded) |
+| DCSREASP | Char | DS | Reason for discontinuation (verbatim) |
+| EOSDT | Num | DS | End of study date |
+| EOSDY | Num | Derived | End of study day relative to TRTSDT |
+
+**Dates and days:**
+
+| Variable | Type | Notes |
+|---|---|---|
+| TRTSDT | Num | First dose date — Date class |
+| TRTEDT | Num | Last dose date — Date class |
+| TRTSDTM | Num | First dose datetime — POSIXct if time in EX |
+| TRTEDTM | Num | Last dose datetime — POSIXct if time in EX |
+| RANDDT | Num | Randomisation date |
+| RANDDY | Num | Randomisation day (relative to TRTSDT) |
+
+---
+
+## Population Flag Variables
+
+Character flags are needed for each analysis population defined
+in the SAP, and at least one must be present for each trial. Standard flags
+include ENRLFL (enrolled), RANDFL (randomised), SAFFL (safety), ITTFL (ITT),
+and FASFL (full analysis set).
+
+### Flag Value Convention
+
+**Critical:** CDISC ADaM convention for flag variables is `"Y"` or `NA`.
+Never use `"N"`.
+
+```r
+# CORRECT
+mutate(SAFFL = if_else(has_dose, "Y", NA_character_))
+
+# WRONG — violates CDISC ADaM convention
+mutate(SAFFL = if_else(has_dose, "Y", "N"))
+```
+
+This applies to ALL flag variables in ADSL: population flags (`--FL`), baseline
+flags (`ABLFL`), and any other indicator variable.
+
+### Standard Population Flags
+
+| Flag | Label | Typical definition |
+|---|---|---|
+| ENRLFL | Enrolled Population Flag | All subjects who signed informed consent |
+| RANDFL | Randomised Population Flag | All subjects who were randomised (DM.ARM not null/screen failure) |
+| SAFFL | Safety Population Flag | Received at least one dose of study treatment (EXDOSE > 0) |
+| ITTFL | Intent-to-Treat Population Flag | Randomised; definition varies — verify against protocol |
+| FASFL | Full Analysis Set Flag | Protocol-defined; often same as ITTFL or broader |
+| PPROTFL | Per-Protocol Population Flag | Highly protocol-specific — always requires statistician input |
+| COMPLFL | Completers Flag | Completed the study per protocol |
+
+**Every population flag derivation must be reviewed against the protocol and SAP.**
+The definitions above are starting points only. Add `# REVIEW:` comments for
+each flag and document the protocol reference.
+
+### Numeric Companion Variables
+
+For any flag used in subgroup analysis, a numeric version is often needed for
+sorting and TLF production:
+
+```r
+mutate(
+  SAFFL  = if_else(has_dose, "Y", NA_character_),
+  SAFFLN = if_else(SAFFL == "Y", 1, NA_real_)
+)
+```
+
+---
+
+## Naming Conventions
+
+### Treatment Period Variables
+
+For multi-period studies, variables follow a strict naming pattern:
+
+| Pattern | Meaning | Example |
+|---|---|---|
+| `TRT0xP` | Planned treatment, period x | TRT01P, TRT02P |
+| `TRT0xA` | Actual treatment, period x | TRT01A, TRT02A |
+| `TRT0xPN` | Numeric code for planned treatment | TRT01PN |
+| `TRT0xAN` | Numeric code for actual treatment | TRT01AN |
+| `TR0xSDT` | Treatment start date, period x | TR01SDT |
+| `TR0xEDT` | Treatment end date, period x | TR01EDT |
+| `AP0xSDT` | Analysis period start date | AP01SDT |
+| `AP0xEDT` | Analysis period end date | AP01EDT |
+
+### Baseline Variables
+
+Baseline values carried into ADSL follow the pattern `{test}BL`:
+
+| Example | Meaning |
+|---|---|
+| HEIGHTBL | Baseline height |
+| WEIGHTBL | Baseline weight |
+| BMIBL | Baseline BMI |
+| CREATBL | Baseline creatinine |
+
+### Categorisation Variables
+
+Grouping/categorisation variables follow `{var}GR{n}` and `{var}GR{n}N`:
+
+| Example | Meaning |
+|---|---|
+| AGEGR1 | Age group 1 (character) |
+| AGEGR1N | Age group 1 numeric |
+| BMIGRP1 | BMI group 1 |
+
+The `N` suffix always denotes the numeric version of a character variable.
+Both must be present if used in analysis.
+
+---
+
+## Controlled Terminology
+
+### SEX
+
+From CDISC CT (SDTM Codelist C66731):
+
+| Code | Decode |
+|---|---|
+| `"F"` | Female |
+| `"M"` | Male |
+| `"U"` | Unknown |
+| `"UNDIFFERENTIATED"` | Undifferentiated |
+
+### RACE
+
+From CDISC CT (SDTM Codelist C74457). Standard values:
+
+- `"AMERICAN INDIAN OR ALASKA NATIVE"`
+- `"ASIAN"`
+- `"BLACK OR AFRICAN AMERICAN"`
+- `"NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER"`
+- `"WHITE"`
+- `"MULTIPLE"`
+- `"OTHER"`
+- `"NOT REPORTED"`
+- `"UNKNOWN"`
+
+When subjects select multiple races, RACE is typically set to `"MULTIPLE"` in
+DM and individual selections are captured in suppDM or a separate variable
+(RACE1, RACE2, etc.).
+
+### ETHNIC
+
+From CDISC CT (SDTM Codelist C66790):
+
+| Code |
+|---|
+| `"HISPANIC OR LATINO"` |
+| `"NOT HISPANIC OR LATINO"` |
+| `"NOT REPORTED"` |
+| `"UNKNOWN"` |
+
+### EOSSTT (End of Study Status)
+
+Common values — verify against study protocol and DS controlled terminology:
+
+| Value | Meaning |
+|---|---|
+| `"COMPLETED"` | Completed the study |
+| `"DISCONTINUED"` | Discontinued before completion |
+
+### DCSREAS (Discontinuation Reason)
+
+Derived from DS.DSDECOD. Common values from CDISC CT (Codelist C66727) include:
+
+- `"ADVERSE EVENT"`
+- `"DEATH"`
+- `"LACK OF EFFICACY"`
+- `"LOST TO FOLLOW-UP"`
+- `"PHYSICIAN DECISION"`
+- `"PROTOCOL DEVIATION"`
+- `"SPONSOR DECISION"`
+- `"SUBJECT DECISION"`
+- `"WITHDRAWAL BY SUBJECT"`
+
+---
+
+## Date Variable Conventions
+
+### Types
+
+| Admiral type | R class | XPT export | When to use |
+|---|---|---|---|
+| Date (`_DT`) | `Date` | Numeric (SAS date) | Date only — no time component |
+| Datetime (`_DTM`) | `POSIXct` | Numeric (SAS datetime) | When time component is present in SDTM |
+
+### Imputation Rules
+
+When SDTM `--DTC` values are partial (e.g. `"2023-06"`, `"2023"`):
+
+| Variable type | Imputation rule | admiral argument |
+|---|---|---|
+| Start dates (TRTSDT, RANDDT) | Impute to **earliest** possible date | `date_imputation = "first"` |
+| End dates (TRTEDT, EOSDT) | Impute to **latest** possible date | `date_imputation = "last"` |
+| Time (when time absent) | Start: `"00:00:00"`, End: `"23:59:59"` | `time_imputation = "first"` / `"last"` |
+
+Imputation flags are auto-generated by admiral (`--DTF`, `--TMF`) and should be
+retained in the dataset. Never suppress imputation flags.
+
+### Study Day Convention
+
+CDISC study day: the reference date is Day 1. There is no Day 0.
+
+| Day | Meaning |
+|---|---|
+| 1 | Reference date (e.g. TRTSDT) |
+| 2 | Day after reference |
+| -1 | Day before reference |
+
+Always use `derive_vars_dy()`. Never compute manually.
+
+---
+
+## Dataset Attributes
+
+### Dataset-Level
+
+| Attribute | Value |
+|---|---|
+| Dataset label | `"Subject-Level Analysis Dataset"` |
+| Dataset name | `ADSL` |
+| One record per | Subject (USUBJID) |
+
+Apply in R using `haven::write_xpt()` with `label` argument, or via `{metacore}`
+and `{xportr}` for spec-driven attribute application:
+
+```r
+# Using xportr (recommended for submission)
+adsl |>
+  xportr_label(metacore, domain = "ADSL") |>
+  xportr_type(metacore, domain = "ADSL") |>
+  xportr_length(metacore, domain = "ADSL") |>
+  xportr_order(metacore, domain = "ADSL") |>
+  xportr_write("adsl.xpt", label = "Subject-Level Analysis Dataset")
+```
+
+### Variable-Level Attributes
+
+Every variable must have:
+- **Label** — from the ADaM spec; max 40 characters
+- **Type** — character or numeric (SAS conventions: Char = `$`, Num = 8-byte float)
+- **Length** — from the ADaM spec; character variables have explicit lengths
+
+Apply labels before export, not during derivation. Derivation steps may strip
+attributes; always apply as a final step.
+
+```r
+# Using Hmisc (simple alternative for non-submission work)
+Hmisc::label(adsl$TRTSDT) <- "Date of First Study Treatment"
+Hmisc::label(adsl$SAFFL)  <- "Safety Population Flag"
+```
+
+---
+
+## define.xml Expectations
+
+ADSL metadata submitted in define.xml must include for each variable:
+
+- Variable name, label, type, length
+- Origin (`Derived`, `Assigned`, or the SDTM source domain/variable)
+- Codelist reference (for variables with controlled terminology)
+- Derivation/comment (derivation logic in plain language)
+- Core status (Required / Conditionally Required / Permissible)
+
+Variables taken directly from SDTM (e.g. AGE, SEX from DM) should have
+origin `"Predecessor"` referencing the SDTM variable, not `"Derived"`.
+
+---
+
+## Variable Order Convention
+
+ADSL variable order in the XPT file should follow the ADaM spec column order.
+Use `xportr_order()` from `{xportr}` to enforce this programmatically from the
+spec metadata. Do not rely on the order variables were added during derivation.
+
+Standard grouping convention (not enforced by CDISC but widely expected):
+
+1. Identifiers (STUDYID, USUBJID, SUBJID, SITEID)
+2. Demographics (AGE, AGEU, AGEGR1, AGEGR1N, SEX, RACE, ETHNIC, COUNTRY)
+3. Treatment (TRT01P, TRT01PN, TRT01A, TRT01AN, TRTSEQP, TRTSEQA)
+4. Dates (RANDDT, TRTSDT, TRTEDT, TRTDURD)
+5. Disposition (EOSSTT, DCSREAS, DCSREASP, EOSDT)
+6. Population flags (ENRLFL, RANDFL, ITTFL, FASFL, SAFFL, PPROTFL)
+7. Stratification variables
+8. Baseline values
+9. Study-specific variables
+
+---
+
+## Common Reviewer Findings (to Avoid)
+
+| Finding | Rule violated | Fix |
+|---|---|---|
+| `SAFFL = "N"` present | Flag convention: `"Y"` or `NA` only | Replace `"N"` with `NA_character_` |
+| ADSL has >1 record per USUBJID | One record per subject | Identify and resolve duplicate |
+| Variable label >40 chars | SAS XPT label length limit | Truncate; align with spec |
+| TRTSDT missing for treated subjects | Required when treatment given | Check EX filter logic |
+| DCSREAS populated for completers | Should be `NA` for subjects who completed | Add `EOSSTT == "DISCONTINUED"` filter |
+| Imputation flag absent | ADaM traceability requirement | Retain `--DTF`/`--TMF` variables |
+| Variables not in spec order in XPT | Submission expectation | Apply `xportr_order()` |
+| TRT01P ≠ DM.ARM for randomised subject | Source mismatch | TRT01P must come from DM.ARM |


### PR DESCRIPTION
Closes #89

Adds the `admiral-adsl` skill — an agent skill for deriving ADaM Subject-Level
Analysis Datasets (ADSL) using the {admiral} R package and pharmaverse ecosystem.

## What's included
- `SKILL.md` — step-by-step derivation workflow (setup → spine → treatment dates → disposition → population flags → attributes)
- `DESIGN.md` — scope decisions and open questions for community input
- `references/admiral-functions.md` — function selection guide (derive_vars_merged, derive_vars_dt, etc.)
- `references/adsl-conventions.md` — CDISC variable, CT, and date conventions
- `benchmarks/README.md` — planned benchmark scaffold (implementations in follow-on PRs)

## Open questions for reviewers (see DESIGN.md)
- OQ-1: Benchmark scope for population flags (standard vs. deferral benchmarks)
- OQ-2: admiral version pinning strategy
- OQ-3: Evaluation depth for `# REVIEW:` annotation quality
