### PR TITLE
clinical-trial-simulation v0.2.6 → v0.2.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,13 +17,13 @@ llms.txt
 # Benchmark run manifest — local only to avoid merge conflicts
 _automation/benchmark-runner/runs/runs.json
 
-group-sequential-design/evals/.DS_Store
+# macOS Finder metadata — anywhere in the tree
+.DS_Store
 
 # clinical-trial-simulation: per-trial run output and rendered HTML
 clinical-trial-simulation/runs/
 clinical-trial-simulation/output/
 clinical-trial-simulation/**/*.html
-clinical-trial-simulation/**/.DS_Store
 .Rproj.user
 
 # /simulate output — repo-root runs/ folder per .claude/commands/simulate.md

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.5
+  version: 0.2.6
 ---
 
 # TrialSimulator Skill

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.8
+  version: 0.2.9
 ---
 
 # TrialSimulator Skill
@@ -39,7 +39,14 @@ Install TrialSimulator from GitHub HEAD, not CRAN — this skill tracks GitHub:
 remotes::install_github("zhangh12/TrialSimulator")
 ```
 
-Capture `packageVersion("TrialSimulator")` in `main.R` and surface it in §0 of the report.
+Capture `packageVersion("TrialSimulator")` and `R.version.string` in `main.R` and write them into `oc_summary.rds` under fixed names (`ts_version`, `r_version`). §0 of the report reads them from there. Do not hardcode the version literal in the report — it must trace back to the actual run.
+
+```r
+# in main.R, before saveRDS:
+oc_summary$ts_version <- as.character(packageVersion("TrialSimulator"))
+oc_summary$r_version  <- R.version.string
+saveRDS(oc_summary, file.path(out_dir, "oc_summary.rds"))
+```
 
 ## Package philosophy
 
@@ -273,12 +280,13 @@ decisions. Don't ask; just do.
   packages when both can do the job. See `helpers.md` for the
   catalog. The package's design intent is that you reach for its
   functions reflexively.
-- **Runnable dummies for unspecified decision rules.** When the user
-  says "we'll decide based on data" without specifying the rule,
-  write a small data-driven dummy and label it: `# DUMMY: replace
-  with actual rule`. Guard against edge cases (`length() > 0` before
-  `remove_arms`, etc.). A dummy that runs is better than a TODO that
-  blocks validation.
+- **Runnable placeholders for unspecified decision rules.** When the
+  user says "we'll decide based on data" without specifying the rule,
+  write a small data-driven placeholder and label it: `# PLACEHOLDER:
+  replace with actual rule`. Use the same `PLACEHOLDER` tag in the §2
+  parameter table (see `report.md`). Guard against edge cases
+  (`length() > 0` before `remove_arms`, etc.). A placeholder that
+  runs is better than a TODO that blocks validation.
 - **Comment action functions liberally.** Action functions encode
   the design's decision logic — the "why" of every threshold, fit,
   adaptation, and save call. Without comments, a QC reviewer has to
@@ -420,10 +428,13 @@ runs/<trial_name>/
                        main.R or actions.R. Keeping it as its own
                        file preserves a reproducible record of where
                        the literals came from.
-  output.rds        ← saved by main.R
+  output.rds        ← raw controller$get_output(), saved by main.R
+  oc_summary.rds    ← post-processed OC list for the report, saved by main.R
   report.md         ← the report
   report.html       ← rendered via markdown::mark_html
-  milestone_times.png ← embedded in the report
+  milestone_times.png ← embedded in the report ONLY when the milestone-time
+                       precondition holds AND the decision tree in
+                       report.md §7 selects "include". Omitted otherwise.
 ```
 
 `main.R` sources whichever sibling files exist:

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,8 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.15
+  version: 0.2.16
+  trialsimulator_min_version: "1.18.4"
 ---
 
 # TrialSimulator Skill
@@ -20,21 +21,32 @@ knowledge; this skill adds what is specific to TrialSimulator.
 
 ## Loading announcement
 
-Whenever this skill is loaded, the **first line of the agent's first
-response** must show the skill version and the running environment:
+Whenever this skill is loaded, the agent calls
+`packageVersion("TrialSimulator")` (fast, local — no network) and
+compares the installed version against
+`metadata.trialsimulator_min_version` from the YAML frontmatter
+above. The first line of the agent's first response reports the
+result.
 
-> `clinical-trial-simulation v<metadata.version> loaded — TrialSimulator <ts_version>, R <r_version>`
+Three outcomes:
 
-Substitute literal values:
+- **Installed ≥ required** — `clinical-trial-simulation v<metadata.version> loaded — TrialSimulator <ts_version>, R <r_version>`. Proceed.
+- **Installed < required** — `clinical-trial-simulation v<metadata.version> loaded — TrialSimulator <ts_version> installed, **≥ <trialsimulator_min_version> required**. R <r_version>.` Then offer to update on the next turn: *"Want me to run `remotes::install_github('zhangh12/TrialSimulator')` now? (y/n)"* — on confirm, run it and re-check; on decline, stop until the user resolves. Do not begin any simulation work until the version requirement is met.
+- **Not installed** — `clinical-trial-simulation v<metadata.version> loaded — TrialSimulator not installed. R <r_version>.` Offer to install: *"Want me to run `remotes::install_github('zhangh12/TrialSimulator')` now? (y/n)"*
 
-- `<metadata.version>` from this file's YAML frontmatter above.
-- `<ts_version>` from `packageVersion("TrialSimulator")` against the **currently-installed** package. The pre-flight install (see "Package source") has not run yet at this point; if it later updates the package, the agent announces the new version explicitly.
-- `<r_version>` from `R.version.string` (the `x.y.z` portion is fine).
+Substitutions:
 
-This applies on every fresh session and on every re-load; the user
-must always see which versions of the skill, the package, and R
-are in play. The announcement itself does not trigger any network
-call.
+- `<metadata.version>` from this file's YAML frontmatter.
+- `<trialsimulator_min_version>` from this file's YAML frontmatter.
+- `<ts_version>` from `packageVersion("TrialSimulator")`.
+- `<r_version>` from `R.version.string` (the `x.y.z` portion).
+
+No network call fires on load. The only network use is the optional
+remediation install on user confirmation.
+
+After the announcement line, briefly greet the user and ask about
+the trial setting — never ask what design type, discover it through
+conversation (see "Two user modes" below).
 
 ## Files in this skill
 
@@ -51,35 +63,32 @@ is the source of truth.
 
 ## Package source
 
-This skill tracks **GitHub HEAD** of TrialSimulator, not CRAN. **At
-the start of the first simulation request in a session — after the
-loading announcement, before any other simulation work — the agent
-runs the pre-flight install:**
+This skill targets a known-good baseline of TrialSimulator declared
+in `metadata.trialsimulator_min_version` of the YAML frontmatter
+above. **At load, only a local `packageVersion("TrialSimulator")`
+check runs — no automatic `install_github`, no network call.** The
+load-time check + offer/auto behavior is specified in "Loading
+announcement".
+
+If TrialSimulator is missing or below the minimum, the canonical
+remediation is:
 
 ```r
-Rscript -e 'remotes::install_github("zhangh12/TrialSimulator", upgrade = "never")'
+remotes::install_github("zhangh12/TrialSimulator")
 ```
 
-This is fast when the installed version's SHA matches HEAD (one
-GitHub API check, no download) and pulls HEAD when it lags. The
-pre-flight does not fire on skill load alone — only when the user
-makes a simulation request. Casual loads of the skill are free.
+The agent offers to run this when the load-time check detects a
+shortfall and only runs it on user confirmation. The user can also
+update outside the session and reload the skill.
 
-Three outcomes the agent must handle visibly:
+When bumping `metadata.version`, audit whether
+`trialsimulator_min_version` also needs to move — e.g., if the
+skill adopts a TS feature or fix landed in a newer release.
 
-- **Already at HEAD.** Proceed silently.
-- **Updated to HEAD.** Announce explicitly, e.g. *"TrialSimulator
-  updated from 1.17.1 to 1.17.2."* §0 of the report uses the new
-  version.
-- **Install failed** (network down, build error). Surface the
-  failure to the user — do not silently fall back to the
-  previously-installed version. The user decides whether to
-  proceed with the existing install or fix the problem.
-
-Surface three versions in §0: TrialSimulator, R, and the skill.
-The agent looks each value up once before writing the report and
-pastes the literal string into the §0 table. No R chunks, no
-runtime lookup, no `readRDS`. Slight staleness on re-renders is
+Surface three versions in §0 of the report: TrialSimulator, R, and
+the skill. The agent looks each value up once before writing the
+report and pastes the literal string into the §0 table. No R chunks,
+no runtime lookup, no `readRDS`. Slight staleness on re-renders is
 acceptable; the running environment is assumed stable.
 
 ## Package philosophy

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.9
+  version: 0.2.10
 ---
 
 # TrialSimulator Skill

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.7
+  version: 0.2.8
 ---
 
 # TrialSimulator Skill
@@ -194,12 +194,32 @@ mentioned X — I didn't use it; where does it fit?"), and ask for
 missing pieces with one sentence of why each matters. Silently
 dropping user-supplied information is a trust killer.
 
-### Plain language for argument collection
+### Plain language during interaction
 
-Every question is collecting an argument value for a building-block
-function — but ask in clinical terms, not as `n_patients = ?`. "How
-many patients do you plan to enroll?" gets the same value with less
-friction.
+Every question to the user is collecting an argument value for a
+building-block function — but ask in **clinical / statistical terms**,
+not in package vocabulary. The same applies when *confirming* the
+parameter table, the analysis plan, or the chosen design: describe
+what the design *does*, not how the code implements it. A
+biostatistician unfamiliar with TrialSimulator should be able to
+follow the conversation with no R reference open.
+
+| Avoid (package vocabulary) | Prefer (clinical / statistical terms) |
+|---|---|
+| "use `fitLogrank` for the OS test" | "OS is tested with a one-sided log-rank test" |
+| "milestone fires at `enrollment(n=500, min_treatment_duration=6)`" | "the analysis is performed 6 months after the last patient is enrolled" |
+| "we'll call `set_duration(54)` if pooled events < 220" | "the trial duration is extended from 48 to 54 months if pooled events at month 24 fall below 220" |
+| "boundary z = 2.523 from `asOF` spending" | "interim efficacy boundary z = 2.523 (Lan-DeMets O'Brien-Fleming spending, IF = 0.71)" |
+| "`StaggeredRecruiter` with `accrual_rate = data.frame(...)`" | "piecewise-constant accrual: 5/mo for the first 3 months, 15/mo for the next 3, then 25/mo until enrollment completes" |
+| "the action saves `gate_pass`" | "the gate decision is recorded for each replicate" |
+| "use `CorrelatedPfsAndOs2`" | "PFS and OS are modeled jointly via a Gumbel copula with Kendall's τ = 0.5 and exponential margins" |
+
+Code-level vocabulary is appropriate in **three contexts only**:
+implementation mode where the user pasted code, debugging an error
+together, or the report itself (whose audience is a QC reviewer who
+must verify the implementation). During design discovery, parameter
+confirmation, and progress updates, default to clinical /
+statistical language.
 
 ### Confirmation gates
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.13
+  version: 0.2.14
 ---
 
 # TrialSimulator Skill
@@ -39,9 +39,7 @@ Install TrialSimulator from GitHub HEAD, not CRAN — this skill tracks GitHub:
 remotes::install_github("zhangh12/TrialSimulator")
 ```
 
-Surface three versions in §0 of the report: TrialSimulator, R, and the skill. The §0 table shows the *values*. How the agent captures them — query the running R, parse `SKILL.md` once, snapshot into the report, whatever is simplest — is implementation detail and **does not appear in the report itself**. Do not embed R code chunks in the report that load or format the version strings.
-
-The running environment is assumed stable enough that slight staleness (e.g., a re-render after a TS update) is acceptable.
+Surface three versions in §0: TrialSimulator, R, and the skill. The agent looks each value up once before writing the report and pastes the literal string into the §0 table. No R chunks, no runtime lookup, no `readRDS`. Slight staleness on re-renders is acceptable; the running environment is assumed stable.
 
 ## Package philosophy
 
@@ -262,38 +260,20 @@ read narrowly to the cited section, then stop.
 ### First response is the plan
 
 The agent's first substantive response — before any R execution,
-before any derivation script, before any simulation — is **the
-plan**, not the result. Every prompt gets one, regardless of
-complexity. This is a soft expectation, not a hard timer: aim to
-have the plan in the user's hands within a couple of minutes of
-receiving the prompt, before any expensive computation begins.
+derivation script, or simulation — is **the plan**, not the result.
+Every prompt gets one. Aim to have it in the user's hands within a
+couple of minutes; soft expectation.
 
-The plan contains:
+The plan contains: a restate of the design; the §2 parameter table
+v0 with `protocol` / `assumed` / `derived (pending)` tags per
+`report.md`; a bullet list of intended supplements (or "no
+supplements needed"); the `assumed` rows called out for
+confirmation; and the next step with a rough time estimate.
 
-1. **Restate** — one short paragraph in the agent's own words
-   confirming what the design is.
-2. **Parameter table v0** — with `protocol` / `assumed` /
-   `derived (pending)` tags per `report.md` §2.
-   `derived (pending)` rows name the supplement that will resolve
-   them; `assumed` rows surface defaults the user can override.
-3. **Supplement plan** — bullet list of non-trivial derivations the
-   agent intends to write, per `report.md` "Pre-simulation
-   derivations and supplements". *"No supplements needed"* is a
-   valid plan; state it.
-4. **Open assumptions** — the `assumed` rows from the parameter
-   table, called out for confirmation, one line each.
-5. **Next step** — what the agent will do next, with a rough time
-   estimate.
-
-The cost is small (one short turn before work begins); the value is
-the user sees what's coming, can correct assumptions early, and can
-interrupt before twenty minutes of silent work.
-
-**Implementation-mode caveat.** When the user says "skip the Q&A"
-or "proceed directly to computation," the plan still gets posted —
-it condenses to a one-paragraph acknowledgment: *"Implementation
-mode. Plan: <N> supplements (<topics>) → main.R → sanity →
-production. Starting now."* Skipping Q&A is not skipping visibility.
+**Implementation-mode caveat.** When the user says "skip the Q&A,"
+the plan condenses to one paragraph (*"Implementation mode. Plan:
+<N> supplements → main.R → sanity → production. Starting now."*)
+but still posts. Skipping Q&A is not skipping visibility.
 
 ### Confirmation gates
 
@@ -319,25 +299,11 @@ the conversation.
 
 ### No silent work
 
-Each derivation supplement is its own visible turn, mirroring the
-"one artifact per turn" cadence the rest of the workflow follows:
-
-- Turn N: *"Writing `scripts/derivations/<topic>.R`."* → write file
-  → stop (let the tool result return).
-- Turn N+1: *"Running it."* → bash run → stop.
-- Turn N+2: *"Got [literals]. Verified [feature] against [target].
-  Rendering `supplements/<topic>.md`."* → write supplement → stop.
-
-Bundling multiple supplements (or multiple validation rounds) into
-a single silent stretch is a violation of this rule. The same
-applies to sanity → calibration → production: each is its own turn,
-and the agent announces what it is about to run before running it.
-
-If any tool call is expected to take more than ~60 seconds (large
-calibration sim, NORTA optimizer, slow `solveThreeStateModel` grid),
-announce it with a rough estimate before launching it (*"Calibration
-sim n=50 across 5 NPH scenarios, ~3 min"*). The user can then
-interrupt without wondering whether anything is happening.
+Each supplement and each validation round (sanity, calibration,
+production) is its own visible turn — write, run, render are
+separate announced turns, never bundled into a single silent
+stretch. Tool calls expected to take more than ~60 seconds get a
+one-line heads-up with a rough estimate before launching.
 
 ### Don't ask about internal workflow
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.14
+  version: 0.2.15
 ---
 
 # TrialSimulator Skill
@@ -17,6 +17,24 @@ a thinking framework, a cached API reference, a TrialSimulator-specific
 function catalog, and a report-writing guide. **It is not a script.**
 You bring general engineering, programming, and biostatistics
 knowledge; this skill adds what is specific to TrialSimulator.
+
+## Loading announcement
+
+Whenever this skill is loaded, the **first line of the agent's first
+response** must show the skill version and the running environment:
+
+> `clinical-trial-simulation v<metadata.version> loaded — TrialSimulator <ts_version>, R <r_version>`
+
+Substitute literal values:
+
+- `<metadata.version>` from this file's YAML frontmatter above.
+- `<ts_version>` from `packageVersion("TrialSimulator")` against the **currently-installed** package. The pre-flight install (see "Package source") has not run yet at this point; if it later updates the package, the agent announces the new version explicitly.
+- `<r_version>` from `R.version.string` (the `x.y.z` portion is fine).
+
+This applies on every fresh session and on every re-load; the user
+must always see which versions of the skill, the package, and R
+are in play. The announcement itself does not trigger any network
+call.
 
 ## Files in this skill
 
@@ -33,13 +51,36 @@ is the source of truth.
 
 ## Package source
 
-Install TrialSimulator from GitHub HEAD, not CRAN — this skill tracks GitHub:
+This skill tracks **GitHub HEAD** of TrialSimulator, not CRAN. **At
+the start of the first simulation request in a session — after the
+loading announcement, before any other simulation work — the agent
+runs the pre-flight install:**
 
 ```r
-remotes::install_github("zhangh12/TrialSimulator")
+Rscript -e 'remotes::install_github("zhangh12/TrialSimulator", upgrade = "never")'
 ```
 
-Surface three versions in §0: TrialSimulator, R, and the skill. The agent looks each value up once before writing the report and pastes the literal string into the §0 table. No R chunks, no runtime lookup, no `readRDS`. Slight staleness on re-renders is acceptable; the running environment is assumed stable.
+This is fast when the installed version's SHA matches HEAD (one
+GitHub API check, no download) and pulls HEAD when it lags. The
+pre-flight does not fire on skill load alone — only when the user
+makes a simulation request. Casual loads of the skill are free.
+
+Three outcomes the agent must handle visibly:
+
+- **Already at HEAD.** Proceed silently.
+- **Updated to HEAD.** Announce explicitly, e.g. *"TrialSimulator
+  updated from 1.17.1 to 1.17.2."* §0 of the report uses the new
+  version.
+- **Install failed** (network down, build error). Surface the
+  failure to the user — do not silently fall back to the
+  previously-installed version. The user decides whether to
+  proceed with the existing install or fix the problem.
+
+Surface three versions in §0: TrialSimulator, R, and the skill.
+The agent looks each value up once before writing the report and
+pastes the literal string into the §0 table. No R chunks, no
+runtime lookup, no `readRDS`. Slight staleness on re-renders is
+acceptable; the running environment is assumed stable.
 
 ## Package philosophy
 
@@ -316,6 +357,17 @@ decisions. Don't ask; just do.
   user doesn't decide whether to run a small sanity check before
   production — the agent does it as part of producing a working
   script. Don't ask.
+
+  **Carve-out — calibration that produces cited literals.** If a
+  calibration script computes a value that ends up in the §2
+  parameter table, in `main.R` / `actions.R`, or anywhere else
+  the report cites it, the script is a **citable artifact**, not
+  internal workflow. It follows the supplement rule (see
+  `report.md` "Derivations and supplements"): script in
+  `scripts/derivations/`, rendered doc in `supplements/`,
+  bidirectional cross-references with the main report. "Internal
+  workflow" applies only to the testing iteration on `main.R`
+  itself.
 - **Seed.** `seed = NULL` (auto per-replicate, recorded in the
   output) is the correct default for simulation studies. Don't ask
   the user about it. Use a fixed integer seed only if the user

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.10
+  version: 0.2.11
 ---
 
 # TrialSimulator Skill
@@ -417,25 +417,35 @@ a `scripts/` subfolder split by purpose:
 ```
 runs/<trial_name>/
   scripts/
-    main.R          ← building blocks: endpoint, arm, trial,
-                       milestone, listener, controller, run, OC summary
-    actions.R       ← action functions (omit if no non-doNothing actions)
-    generators.R    ← custom generator functions (omit if none)
-    helpers.R       ← helpers used by generators or actions (omit if none)
-    boundaries.R    ← external boundary computation via rpact /
-                       gsDesign (omit if not used). Run ONCE before
-                       main.R; the literal results are hardcoded in
-                       main.R or actions.R. Keeping it as its own
-                       file preserves a reproducible record of where
-                       the literals came from.
-  output.rds        ← raw controller$get_output(), saved by main.R
-  oc_summary.rds    ← post-processed OC list for the report, saved by main.R
-  report.md         ← the report
-  report.html       ← rendered via markdown::mark_html
-  milestone_times.png ← embedded in the report ONLY when the milestone-time
-                       precondition holds AND the decision tree in
-                       report.md §7 selects "include". Omitted otherwise.
+    main.R               ← building blocks: endpoint, arm, trial,
+                            milestone, listener, controller, run, OC summary
+    actions.R            ← action functions (omit if no non-doNothing actions)
+    generators.R         ← custom generator functions (omit if none)
+    helpers.R            ← helpers used by generators or actions (omit if none)
+    boundaries.R         ← external boundary computation via rpact /
+                            gsDesign (omit if not used). Run ONCE before
+                            main.R; the literal results are hardcoded in
+                            main.R or actions.R.
+    derivations/         ← one R script per non-trivial pre-simulation
+      <topic>.R             derivation (correlation fitting, NORTA
+                            feasibility, landmark-to-piecewise, gate-
+                            threshold calibration, etc.). Run ONCE
+                            before main.R; literals hardcoded forward.
+                            See report.md "Pre-simulation derivations
+                            and supplements".
+  supplements/           ← rendered supplement docs (one per
+    <topic>.md              derivations/<topic>.R). Each cross-
+    <topic>.html            referenced from §2 of report.md.
+  output.rds             ← raw controller$get_output(), saved by main.R
+  oc_summary.rds         ← post-processed OC list for the report, saved by main.R
+  report.md              ← the main report
+  report.html            ← rendered via markdown::mark_html
+  milestone_times.png    ← embedded in the report ONLY when the milestone-time
+                            precondition holds AND the decision tree in
+                            report.md §7 selects "include". Omitted otherwise.
 ```
+
+`scripts/derivations/` and `supplements/` are present only when the design has non-trivial pre-simulation derivations; omit when every derivation is trivial enough to stay inline in §2 of the main report.
 
 `main.R` sources whichever sibling files exist:
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.11
+  version: 0.2.12
 ---
 
 # TrialSimulator Skill
@@ -228,17 +228,107 @@ must verify the implementation). During design discovery, parameter
 confirmation, and progress updates, default to clinical /
 statistical language.
 
+### Don't silently read referenced documents
+
+When a prompt references an external SAP, protocol, or other
+document, the prompt itself distills the relevant content — that
+is the prompt-writer's job. **Do not silently read or fetch the
+referenced document**: no unprompted `Read` on a local PDF, no
+`WebFetch`, no `curl`. A long SAP can cost minutes of context and
+time and may reintroduce ambiguity the prompt was written to
+resolve.
+
+If something the prompt does not cover would meaningfully change
+the plan and the referenced document plausibly holds the answer,
+**ask the user first**. Name the section or topic, explain why
+reading it would help, and let the user choose: authorize a narrow
+read, paraphrase from memory, or leave the value as `assumed` with
+a default. Reading is on the table when the user authorizes it —
+just never silently.
+
+When the prompt itself explicitly tells the agent to consult the
+source (e.g., "see Section 7.3 of the SAP for the boundary table"),
+read narrowly to the cited section, then stop.
+
+### First response is the plan
+
+The agent's first substantive response — before any R execution,
+before any derivation script, before any simulation — is **the
+plan**, not the result. Every prompt gets one, regardless of
+complexity. This is a soft expectation, not a hard timer: aim to
+have the plan in the user's hands within a couple of minutes of
+receiving the prompt, before any expensive computation begins.
+
+The plan contains:
+
+1. **Restate** — one short paragraph in the agent's own words
+   confirming what the design is.
+2. **Parameter table v0** — with `protocol` / `assumed` /
+   `derived (pending)` tags per `report.md` §2.
+   `derived (pending)` rows name the supplement that will resolve
+   them; `assumed` rows surface defaults the user can override.
+3. **Supplement plan** — bullet list of non-trivial derivations the
+   agent intends to write, per `report.md` "Pre-simulation
+   derivations and supplements". *"No supplements needed"* is a
+   valid plan; state it.
+4. **Open assumptions** — the `assumed` rows from the parameter
+   table, called out for confirmation, one line each.
+5. **Next step** — what the agent will do next, with a rough time
+   estimate.
+
+The cost is small (one short turn before work begins); the value is
+the user sees what's coming, can correct assumptions early, and can
+interrupt before twenty minutes of silent work.
+
+**Implementation-mode caveat.** When the user says "skip the Q&A"
+or "proceed directly to computation," the plan still gets posted —
+it condenses to a one-paragraph acknowledgment: *"Implementation
+mode. Plan: <N> supplements (<topics>) → main.R → sanity →
+production. Starting now."* Skipping Q&A is not skipping visibility.
+
 ### Confirmation gates
 
-Two confirmation gates before any expensive work:
+Three confirmation points across a run, posted in this order:
 
-1. **Parameter table.** Present every value (distribution parameters,
-   readout times, sample size, accrual, dropout, milestone triggers,
-   stratification factors, helper-derived literals). User confirms.
-2. **Save plan.** For every operating characteristic the user wants
-   to know, show which value will be saved in which action function.
-   Catches save↔OC mismatches that are expensive to fix
+1. **The plan** — see "First response is the plan" above. The first
+   gate is the plan, not a complete parameter table; the table is
+   v0 with `derived (pending)` rows for anything a supplement will
+   resolve.
+2. **The resolved parameter table.** After supplements have run and
+   the `pending` rows are filled in, present the final parameter
+   table. The user confirms the literals.
+3. **The save plan.** For every operating characteristic the user
+   asked about, show which value will be saved in which action
+   function. Catches save ↔ OC mismatches that are expensive to fix
    post-simulation.
+
+For implementation-mode prompts that say "skip Q&A," gates (2) and
+(3) collapse into visible turn-by-turn progress (see "No silent
+work" below) rather than explicit confirmation requests, but the
+artifacts (resolved parameter table, save plan) still appear in
+the conversation.
+
+### No silent work
+
+Each derivation supplement is its own visible turn, mirroring the
+"one artifact per turn" cadence the rest of the workflow follows:
+
+- Turn N: *"Writing `scripts/derivations/<topic>.R`."* → write file
+  → stop (let the tool result return).
+- Turn N+1: *"Running it."* → bash run → stop.
+- Turn N+2: *"Got [literals]. Verified [feature] against [target].
+  Rendering `supplements/<topic>.md`."* → write supplement → stop.
+
+Bundling multiple supplements (or multiple validation rounds) into
+a single silent stretch is a violation of this rule. The same
+applies to sanity → calibration → production: each is its own turn,
+and the agent announces what it is about to run before running it.
+
+If any tool call is expected to take more than ~60 seconds (large
+calibration sim, NORTA optimizer, slow `solveThreeStateModel` grid),
+announce it with a rough estimate before launching it (*"Calibration
+sim n=50 across 5 NPH scenarios, ~3 min"*). The user can then
+interrupt without wondering whether anything is happening.
 
 ### Don't ask about internal workflow
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.12
+  version: 0.2.13
 ---
 
 # TrialSimulator Skill
@@ -39,14 +39,9 @@ Install TrialSimulator from GitHub HEAD, not CRAN — this skill tracks GitHub:
 remotes::install_github("zhangh12/TrialSimulator")
 ```
 
-Capture `packageVersion("TrialSimulator")` and `R.version.string` in `main.R` and write them into `oc_summary.rds` under fixed names (`ts_version`, `r_version`). §0 of the report reads them from there. Do not hardcode the version literal in the report — it must trace back to the actual run.
+Surface three versions in §0 of the report: TrialSimulator, R, and the skill. The §0 table shows the *values*. How the agent captures them — query the running R, parse `SKILL.md` once, snapshot into the report, whatever is simplest — is implementation detail and **does not appear in the report itself**. Do not embed R code chunks in the report that load or format the version strings.
 
-```r
-# in main.R, before saveRDS:
-oc_summary$ts_version <- as.character(packageVersion("TrialSimulator"))
-oc_summary$r_version  <- R.version.string
-saveRDS(oc_summary, file.path(out_dir, "oc_summary.rds"))
-```
+The running environment is assumed stable enough that slight staleness (e.g., a re-render after a TS update) is acceptable.
 
 ## Package philosophy
 
@@ -121,9 +116,23 @@ action_<name> <- function(trial, ...) {
 ```
 
 Signature is `function(trial, ...)`. Use distinct `name`s across
-`trial$save()` calls. For state between milestones use
-`trial$save_custom_data(..., overwrite = TRUE)` + `trial$get(name)`
-(see helpers.md gotchas).
+`trial$save()` calls.
+
+**Passing state between milestones — prefer `trial$save()` +
+`trial$get_output()` for scalars.** When milestone A computes a
+single value (number, flag, string, integer ID) that milestone B
+needs to read, save it with `trial$save(value, name)` at A and
+retrieve it at B with `trial$get_output()` (the in-progress
+per-replicate row, sanctioned for use inside actions). This keeps
+the value in the audit trail — it appears as a column in
+`controller$get_output()` after the run, useful for post-hoc
+analysis and report tables.
+
+Reserve `trial$save_custom_data(..., overwrite = TRUE)` +
+`trial$get(name)` for **non-tabular state**: a fitted model object,
+a list, a data frame — anything that does not fit cleanly as a
+column in the per-replicate output. See `helpers.md` gotchas for
+the namespace and `overwrite = TRUE` rules.
 
 ## R6 method visibility — only use the documented public methods
 
@@ -485,6 +494,19 @@ Read the message — TrialSimulator's are usually specific. Consult
 not work) or the pkgdown reference page. Vignettes live at
 https://zhangh12.github.io/TrialSimulator/articles/. Don't disable a
 check to make an error go away.
+
+## Final step — open the main report
+
+After the report and all supplements have been rendered, **open the
+main report HTML in the user's default browser**:
+
+```r
+Rscript -e 'browseURL("runs/<trial_name>/report.html")'
+```
+
+This is the last announced turn of the run, not the user's
+responsibility to remember. Only the main report opens; supplements
+are linked from it. Full guidance in `report.md` §"Output format".
 
 ## Iteration and runtime
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.6
+  version: 0.2.7
 ---
 
 # TrialSimulator Skill

--- a/clinical-trial-simulation/references/building_blocks.md
+++ b/clinical-trial-simulation/references/building_blocks.md
@@ -83,29 +83,18 @@ ep_exp <- endpoint(
 
 # Correlated PFS + OS — CorrelatedPfsAndOs3 (3-state illness-death model, Pearson correlation)
 # WARNING: produces time-varying HR between arms — NOT compatible with Cox PH model.
-# Use solveThreeStateModel() to derive h01/h02/h12 from medians + target Pearson corr; run per arm.
+# Run solveThreeStateModel() per arm to derive h01/h02/h12 from medians + target Pearson corr;
+# only the control arm is shown below — repeat with the experimental arm's medians.
 pars_ctrl <- solveThreeStateModel(
   median_pfs = 8,  median_os = 18,
   corr = seq(0.55, 0.65, by = 0.01), h12 = seq(0.01, 0.50, length.out = 100)
 )
 best_ctrl <- pars_ctrl[which.min(pars_ctrl$error), ]
 
-pars_exp <- solveThreeStateModel(
-  median_pfs = 12, median_os = 24,
-  corr = seq(0.55, 0.65, by = 0.01), h12 = seq(0.01, 0.50, length.out = 100)
-)
-best_exp <- pars_exp[which.min(pars_exp$error), ]
-
 ep_ctrl <- endpoint(
   name      = c("pfs", "os"), type = c("tte", "tte"),
   generator = CorrelatedPfsAndOs3,
   h01 = best_ctrl$h01, h02 = best_ctrl$h02, h12 = best_ctrl$h12,
-  pfs_name  = "pfs", os_name = "os"
-)
-ep_exp <- endpoint(
-  name      = c("pfs", "os"), type = c("tte", "tte"),
-  generator = CorrelatedPfsAndOs3,
-  h01 = best_exp$h01, h02 = best_exp$h02, h12 = best_exp$h12,
   pfs_name  = "pfs", os_name = "os"
 )
 

--- a/clinical-trial-simulation/references/building_blocks.md
+++ b/clinical-trial-simulation/references/building_blocks.md
@@ -176,6 +176,12 @@ ep_visits <- endpoint(
 # Add <name>_event = 1L for each TTE variable; tte/non-tte is declared in endpoint(), not here.
 # If piecewise exponential marginal: use qPiecewiseExponential(p, times, piecewise_risk).
 # Always validate after defining the endpoint — see validation/validate.md.
+#
+# Critical: set BOTH seeds — `seed_initial` in simdesign_norta() (controls
+# the NORTA correlation-search) and `seed` in simulate_data() (controls
+# per-call sampling). Use distinct random integers for each
+# (`sample(.Machine$integer.max, 1)`); reusing the same seed across the two
+# functions degrades randomness quality.
 
 Sigma <- matrix(c(
   1.00, 0.30, 0.20, 0.10,
@@ -191,11 +197,16 @@ design <- simdesign_norta(
     function(p) qbinom(p, size = 1, prob = <prev>),        # baseline binary
     function(p) qunif(p, min = 0, max = 1)                 # baseline uniform
   ),
-  cor_target_final = Sigma
+  cor_target_final = Sigma,
+  seed_initial     = sample(.Machine$integer.max, 1)
 )
 
 gen_norta <- function(n, ...) {
-  df <- as.data.frame(simulate_data(generator = design, n = n))
+  df <- as.data.frame(simulate_data(
+    generator = design,
+    n         = n,
+    seed      = sample(.Machine$integer.max, 1)   # fresh, distinct from seed_initial
+  ))
   colnames(df) <- c("os", "secondary", "baseline_bin", "baseline_unif")
   df$os_event <- 1L  # censoring handled by trial(dropout = ...)
   df

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -355,7 +355,8 @@ practical options:
 
 Get the user's choice on record before writing the script. The
 parameter table's "Source / Notes" column should mark the resulting
-global rate as `user (translated)` or `derived` with the rationale.
+global rate as `protocol (derived)` or `derived` with the rationale,
+per the controlled vocabulary in `report.md` §2.
 
 ### `add_regimen` must precede `add_arms`
 

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -218,9 +218,15 @@ q_pfs <- function(p) {
 design <- simdesign_norta(
   dist             = list(q_pfs,
                           function(p) qexp(p, rate = log(2) / 18)),         # OS marginal
-  cor_target_final = matrix(c(1, 0.6, 0.6, 1), nrow = 2)
+  cor_target_final = matrix(c(1, 0.6, 0.6, 1), nrow = 2),
+  seed_initial     = sample(.Machine$integer.max, 1)                        # see seeds note in building_blocks.md
 )
 ```
+
+Inside the generator that wraps this design, also pass
+`seed = sample(.Machine$integer.max, 1)` to `simulate_data()` — distinct
+from `seed_initial`. See the NORTA worked example in `building_blocks.md`
+for the full seed convention.
 
 After defining the endpoint, validate that realized survival at the
 landmark times matches the input (small Monte Carlo check) — confirms

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -180,13 +180,51 @@ generators need.
 |---|---|
 | Medians + Kendall's tau, Cox/LR planned | `CorrelatedPfsAndOs2` directly (no solver) |
 | Medians + Pearson correlation, non-Cox analysis | `solveThreeStateModel` → `CorrelatedPfsAndOs3` (hardcode literals) |
-| Survival probability at K landmarks | `solvePiecewiseConstantExponentialDistribution` → `PiecewiseConstantExponentialRNG` |
+| Survival probability at K landmarks, independent endpoint | `solvePiecewiseConstantExponentialDistribution` → `PiecewiseConstantExponentialRNG` |
+| Survival probability at K landmarks, correlated with other endpoints (NORTA) | `solvePiecewiseConstantExponentialDistribution` → `qPiecewiseExponential` (see recipe below) |
 | Marker subgroup medians + overall median (or vice versa) | `solveMixtureExponentialDistribution` → custom mixture generator |
 | Dropout at 2 landmarks | `weibullDropout` → `dropout = rweibull, scale, shape` |
 | Dropout at 1 landmark | exponential is the simple default: `dropout = rexp, rate = -log(1-p)/t`. If the user has a different model in mind (e.g., heavier early dropout, time-varying), build a custom dropout function whose first argument is `n` and pass it as `trial(dropout = my_fn, ...)`. |
 | Constant uniform accrual | none — `accrual_rate = data.frame(end_time = Inf, piecewise_rate = N)` |
 | Ramp-up accrual | none — multi-row `accrual_rate` |
 | Recruitment pause window | none — set `piecewise_rate` near zero for the pause window |
+
+### Bridge: piecewise-exp marginal in a NORTA copula
+
+Given landmark survival probabilities for one endpoint that needs to be
+correlated with others, the path is:
+`solvePiecewiseConstantExponentialDistribution` → `qPiecewiseExponential` →
+`simdata::simdesign_norta`. The non-obvious detail is the length mismatch:
+the solver returns K rows (one per landmark), but `qPiecewiseExponential`
+requires `length(piecewise_risk) == length(times) + 1` — so you must
+**append one tail hazard** for the interval beyond the last landmark.
+Common default: repeat the last hazard (smooth extrapolation).
+
+```r
+sched <- solvePiecewiseConstantExponentialDistribution(
+  surv_prob = c(0.80, 0.55, 0.30),
+  times     = c(6, 12, 24)
+)
+# sched: data.frame(end_time, piecewise_risk), K=3 rows.
+
+q_pfs <- function(p) {
+  qPiecewiseExponential(
+    p              = p,
+    times          = sched$end_time,                                       # K
+    piecewise_risk = c(sched$piecewise_risk, sched$piecewise_risk[nrow(sched)])  # K+1
+  )
+}
+
+design <- simdesign_norta(
+  dist             = list(q_pfs,
+                          function(p) qexp(p, rate = log(2) / 18)),         # OS marginal
+  cor_target_final = matrix(c(1, 0.6, 0.6, 1), nrow = 2)
+)
+```
+
+After defining the endpoint, validate that realized survival at the
+landmark times matches the input (small Monte Carlo check) — confirms
+both the length-bridge and the NORTA construction.
 
 ---
 

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -368,6 +368,19 @@ tr$add_arms(sample_ratio, ...)   # errors otherwise
 
 ### `save_custom_data` namespace + `overwrite`
 
+**Prefer `trial$save()` + `trial$get_output()` for scalar state.**
+When the value being passed between milestones is a single
+number, flag, string, or integer (e.g., the index of the selected
+arm, an interim p-value, a binary "gate passed" flag), use
+`trial$save(value, name)` at the saving milestone and
+`trial$get_output()` at the retrieving milestone — the scalar then
+also appears in `controller$get_output()` as a column, available
+to post-hoc analysis. `trial$save_custom_data()` is appropriate
+only when the value is **non-tabular** (a list, a fitted model
+object, a data frame) and would not fit cleanly as a column.
+
+For the cases where `save_custom_data()` is the right tool:
+
 `save()` and `save_custom_data()` share a name registry. Calling both
 with the same `name` errors with "X has been used to name something in
 custom data." Use **distinct** names.
@@ -378,16 +391,16 @@ replicate 2 errors on the duplicate name. **Always set
 `overwrite = TRUE` on `save_custom_data()`.**
 
 ```r
-trial$save_custom_data(value = best_arm, name = "selected", overwrite = TRUE)
-trial$save(value = best_arm, name = "selected_arm")
+# Non-tabular state: a fitted Cox model object passed to a later milestone.
+trial$save_custom_data(value = cox_fit, name = "cox_model", overwrite = TRUE)
 ```
 
 When retrieving in a later milestone, guard against `NULL` (the
 saving milestone may not have fired):
 
 ```r
-selected <- trial$get(name = "selected")
-if (is.null(selected)) selected <- "<fallback>"
+model <- trial$get(name = "cox_model")
+if (is.null(model)) model <- <fallback>
 ```
 
 ### Trials never stop early in simulation

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -43,48 +43,25 @@ Use these inside `endpoint(generator = ...)`.
 
 ### endpoint() grouping rule
 
-Each `endpoint()` call defines **one set of endpoints generated
-together by a single generator function**. Endpoints across
-**separate** `endpoint()` calls are independent — the package
-invokes each set's generator independently.
+Endpoints that need to be correlated must share **one** `endpoint()`
+call (the joint generator returns one column per endpoint, plus
+`<name>_event` for TTE). Independent endpoints go in separate
+`endpoint()` calls. Single-endpoint calls can use a base-R RNG
+(`rexp`, `rnorm`, `rbinom`); multi-endpoint calls require a custom
+or built-in joint generator returning a `data.frame`.
 
-Two orthogonal decisions:
-
-- **How many endpoints per `endpoint()` call?** This is determined by
-  how endpoints group into independent vs. correlated sets. Endpoints
-  that need to be correlated must share one `endpoint()` call;
-  endpoints that are independent of each other can be split across
-  separate calls.
-- **Which generator to use?**
-  - If a call defines exactly **one** endpoint, the generator can be
-    a simple base-R RNG (`rexp`, `rnorm`, `rbinom`, ...) or a custom
-    function.
-  - If a call defines **two or more** endpoints together, the
-    generator MUST be a custom (or built-in) joint generator returning
-    a `data.frame` with one column per endpoint (plus `<name>_event`
-    columns for TTE endpoints). Base-R RNGs only emit one variable,
-    so they cannot be used for multi-endpoint calls.
-
-> **Custom data models — always on the table.** Whenever the user
-> has their own data model (a specific distribution, mechanistic
-> model, empirical resampling, a custom copula, NORTA, anything),
-> help implement it as a custom generator. Base-R RNGs and built-in
-> joint generators are convenient defaults, not the only options.
-> The contract: `function(n, ...)` returning a `data.frame` with one
-> column per endpoint name (plus `<name>_event` columns for TTE).
-> First argument must be `n` — wrap if it isn't (e.g., `base::sample`
-> uses `x`). See `?endpoint` and `building_blocks.md` for details.
+Custom generators are always on the table — any user-supplied data
+model (specific distribution, mechanistic, empirical, custom
+copula, NORTA) is a candidate. Contract: `function(n, ...)`
+returning a `data.frame` with one column per endpoint name (plus
+`<name>_event` for TTE). First argument must be `n` — wrap if it
+isn't (e.g., `base::sample` uses `x`).
 
 Examples:
 
-- PFS and OS, modeled as independent → two `endpoint()` calls, each
-  with `rexp`.
-- PFS and OS, modeled as correlated → one `endpoint()` call with
-  `CorrelatedPfsAndOs2` (or a custom joint generator).
-- PFS+OS correlated, plus three biomarkers correlated among
-  themselves but independent of PFS/OS → one `endpoint()` call for
-  {pfs, os} with a joint generator, and another `endpoint()` call for
-  the three biomarkers with a different joint generator.
+- PFS and OS, independent → two `endpoint()` calls, each with `rexp`.
+- PFS and OS, correlated → one `endpoint()` call with `CorrelatedPfsAndOs2` (or a custom joint generator).
+- PFS+OS correlated, plus three biomarkers correlated among themselves but independent of PFS/OS → one `endpoint()` call for {pfs, os}, another for the three biomarkers.
 
 ### TTE — piecewise / non-PH
 

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -74,6 +74,7 @@ same sequence. Each section pairs (a) the relevant code snippet,
 parameters used, (c) caveats inline if any.
 
 ```
+   Table of Contents                  — clickable links to every section below
 0. Resource Utilization              — session tokens, cost, software versions
 0.5 Output Files and Reproduction    — file tree + reproduction recipe
 1. Design Rationale                  — context, alternatives considered, choices
@@ -96,6 +97,14 @@ each pair a code block with explanation. **The listener and the
 `controller(...) / controller$run()` calls are plumbing — omit them
 from the report.** They are identical across designs and add noise to
 the audit trail.
+
+### Table of Contents (required)
+
+Every report begins with a clickable ToC after the H1 title and
+before §0. Use GFM anchors (`markdown::mark_html` generates them).
+Include every section that exists in this report and nest §7
+subsections when present. Use a bold `**Table of Contents**` label
+(not an H2) so the ToC does not list itself.
 
 ### Code style in the report
 

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -147,8 +147,8 @@ Recommended format:
 | Total cost (USD) | $... |
 | Model | claude-opus-4-7 (or actual) |
 | Session duration | hh:mm |
-| TrialSimulator version | required; capture via `packageVersion("TrialSimulator")` |
-| R version | e.g., `4.5.2` |
+| TrialSimulator version | required; read from `oc_summary$ts_version` (written by `main.R` per SKILL.md §"Package source") — never hardcode the literal in the report |
+| R version | required; read from `oc_summary$r_version` |
 
 ### 0.5 Output Files and Reproduction
 
@@ -192,6 +192,20 @@ runs/<trial_name>/
 └── report.html         31K    rendered via markdown::mark_html
 ````
 
+Convention for the two `.rds` files:
+
+- **`output.rds`** is the raw per-replicate matrix returned by
+  `controller$get_output()`. One row per replicate, all auto-saved
+  milestone columns and all `trial$save()` columns present. Large,
+  reproduction artifact, not consumed directly by the report.
+- **`oc_summary.rds`** is the post-processed list of operating
+  characteristics that the report reads. Whatever summary the report
+  cites (power, P(stop) per stage, MCSE, binding-aware expected
+  duration, `ts_version`, `r_version`, …) is computed in `main.R`
+  *after* the simulation and saved here. The report never recomputes
+  from `output.rds` — that would couple report rendering to the raw
+  schema and defeat the audit trail.
+
 **Reproduction:**
 
 ```sh
@@ -232,7 +246,7 @@ restating numbers.
 **Source / Notes — controlled vocabulary** (use one; combine with a short justification when needed):
 
 - **`protocol`** — copied verbatim from the protocol or user-supplied specification.
-- **`protocol (transformed)`** — protocol-specified in clinical terms, mechanically transformed to a TS-compatible form. The transformation must be shown, e.g. *"15% dropout by mo 50 → `rate = -log(0.85)/50`"*.
+- **`protocol (derived)`** — protocol-specified in clinical terms, mechanically converted to a TS-compatible form. The conversion must be shown, e.g. *"15% dropout by mo 50 → `rate = -log(0.85)/50`"*.
 - **`assumed`** — not specified by the protocol; a default value was selected. The default and its basis must be stated in one phrase, e.g. *"assumed — 6-month ORR readout typical of solid-tumor trials"*. **Assumed values require explicit confirmation before the production simulation is executed.**
 - **`derived`** — computed from other parameters in this table or from a helper function. The computation must be cited, e.g. *"derived: `solveThreeStateModel(median_pfs=7, median_os=15, corr=0.68) → h01 = 0.0750`"*, or *"derived from `boundaries.R` (rpact)"*.
 - **`software default`** — a default prescribed by the package or skill convention (e.g., `seed = NULL`, `silent = TRUE`, `plot_event = FALSE`). No rationale required.
@@ -246,14 +260,16 @@ Always include rows for: endpoint distribution parameters per arm, readout times
 |---|---|---|
 | N (1:1) | 500 | protocol |
 | Accrual | uniform 20/mo (`StaggeredRecruiter`, `accrual_rate = data.frame(end_time=Inf, piecewise_rate=20)`) | protocol |
-| Dropout | exponential, `rate = -log(0.85)/50 = 0.003250` | protocol (transformed): "15% by mo 50" |
+| Dropout | exponential, `rate = -log(0.85)/50 = 0.003250` | protocol (derived): "15% by mo 50" |
 | ORR readout | 6 mo | assumed — first response assessment typical for solid-tumor trials; confirm before production |
 | PFS — control | `rexp(rate = log(2)/20)` | protocol |
 | PFS — treatment, 6-mo delay scenario | `PiecewiseConstantExponentialRNG(risk = data.frame(end_time=c(6,1000), piecewise_risk=c(log(2)/20, 0.55*log(2)/20)))` | derived from protocol NPH specification; `tail_end = 1000` per package convention |
 | GSD efficacy bounds (z) | (3.0204, 2.3762, 2.0303) at IF (0.49, 0.75, 1.00) | derived from `boundaries.R` (rpact, asOF, alpha=0.024) |
 | D_total | 269 events | derived from `boundaries.R` (rpact, 90% power assumption) |
-| Combination test alpha allocation | **PLACEHOLDER:** equal split | PLACEHOLDER — replace with the protocol's pre-specified allocation |
+| Combination test alpha allocation | equal split | PLACEHOLDER — replace with the protocol's pre-specified allocation |
 | Seed | `NULL` (auto per replicate) | software default |
+
+The `PLACEHOLDER` tag in the Source / Notes column is the single signal — do not also wrap the Value column with a `**PLACEHOLDER:**` prefix. One tag, one column.
 
 ### 2.5 Decision Boundary Derivation (only if external tools were used)
 
@@ -364,11 +380,12 @@ After (not before) the code block, add a short narrative covering:
 - **Data lock** — what `get_locked_data` returns at this point;
   which arms / endpoints are populated.
 - **Analysis** — which test, which wrapper, why this choice. **If
-  a stub for a combination/group-sequential test, flag it
-  prominently.**
+  a placeholder for a combination/group-sequential test, flag it
+  prominently using the `PLACEHOLDER` tag (same vocabulary as §2).**
 - **Adaptation** — which `trial$*()` methods are called, with the
-  rule. **If a dummy rule, flag it: "DUMMY: replace with actual
-  rule."**
+  rule. **If a placeholder rule, flag it as `# PLACEHOLDER: replace
+  with actual rule` in the code and as `PLACEHOLDER` in the §2 row
+  that captures the rule.**
 - **What gets saved** — each `trial$save()` mapped to which
   operating characteristic it supports.
 

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -42,17 +42,20 @@ parameters — how each non-trivial literal was obtained from the
 user's brief — may live in a supplement under `supplements/`. The
 main report shows the final literal and a clickable cross-reference
 to the supplement. Each supplement is itself self-contained for its
-own derivation. See "Pre-simulation derivations and supplements"
+own derivation. See "Derivations and supplements"
 below.
 
-## Pre-simulation derivations and supplements
+## Derivations and supplements
 
-Many simulation parameters are derived from the user's brief before
-the simulation runs — boundary literals, distribution calibrations
-to match target medians or landmark survival, correlation parameter
-fitting, NORTA feasibility checks, gate thresholds matched to a
-desired pass probability. Surface these derivations transparently
-using the threshold below.
+Many simulation parameters are derived from the user's brief —
+boundary literals, distribution calibrations to match target
+medians or landmark survival, correlation parameter fitting, NORTA
+feasibility checks, gate thresholds matched to a desired pass
+probability, information-fraction calibrations, and any other
+script-produced literal cited in the report. The rule applies
+regardless of when the derivation runs (before, during, or after
+the main simulation): any script producing a number that ends up
+in the report goes through the supplement contract below.
 
 | Complexity | Where it lives |
 |---|---|
@@ -166,12 +169,14 @@ label (not an H2) so the ToC does not list itself.
 ### Cross-references between sections (clickable)
 
 When one section refers to another, use a markdown anchor link —
-not bare prose. Applies inside the main report and between main
-and supplements.
-
-Before opening the HTML for the user, verify every cross-reference
-and ToC link resolves to an existing anchor in the rendered HTML.
-Fix any broken ones and re-render.
+not bare prose. `markdown::mark_html` generates anchors with a
+fixed prefix: `chp:<slug>` for the H1 and `sec:<slug>` for every
+H2 / H3. The slug is the heading text lowercased, with `§` dropped
+and every period + space replaced by `-`. Example:
+`## §0.5 Output Files and Reproduction` → `sec:0-5-output-files-and-reproduction`.
+Apply the same format in the ToC, in cross-references inside the
+main report, and in supplement-to-main back-references
+(`../report.html#sec:<slug>`).
 
 ### Code style in the report
 
@@ -193,9 +198,17 @@ user should not have to run an extra command.
 
 Retrieve session usage via whatever telemetry the agent has access
 to (e.g., `/cost` output if capturable, session JSONL log, etc.).
-If automated retrieval truly isn't possible, leave a placeholder
-and ask the user to paste `/cost` numbers — but make a real effort
-first.
+**If a value cannot be obtained automatically, the report shows a
+placeholder AND the agent's last announced turn before opening the
+HTML explicitly requests the value from the user**, e.g.
+*"Couldn't retrieve token / cost / session-duration from telemetry
+— please paste `/cost` output and I'll fill in §0."* A bare
+placeholder with no follow-up question is a violation.
+
+**Skill version is never a placeholder.** It is always a literal,
+looked up once from `SKILL.md`'s YAML frontmatter (`metadata.version`)
+before the report is written. The skill file is in the agent's
+context — there is no excuse for placeholder here.
 
 Recommended format:
 
@@ -382,7 +395,7 @@ event-triggered on PFS, FA event-triggered on OS, with information
 fractions that require additional reasoning beyond what
 `getDesignGroupSequential` accepts), move the verbatim call,
 output, and any custom math to `supplements/boundaries.md` per the
-"Pre-simulation derivations and supplements" rules, and leave a
+"Derivations and supplements" rules, and leave a
 one-paragraph summary plus link in §2.5.
 
 ### 3. Treatment Arms and Endpoints

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -35,6 +35,74 @@ failed its QC purpose.
 This sometimes means duplicating a code block across reports.
 Duplication is fine; broken cross-references at audit time are not.
 
+**Carve-out for supplements (provenance).** The main report is
+self-contained for the **design specification, the simulation code,
+and the operating characteristics**. The *provenance* of derived
+parameters — how each non-trivial literal was obtained from the
+user's brief — may live in a supplement under `supplements/`. The
+main report shows the final literal and a clickable cross-reference
+to the supplement. Each supplement is itself self-contained for its
+own derivation. See "Pre-simulation derivations and supplements"
+below.
+
+## Pre-simulation derivations and supplements
+
+Many simulation parameters are derived from the user's brief before
+the simulation runs — boundary literals, distribution calibrations
+to match target medians or landmark survival, correlation parameter
+fitting, NORTA feasibility checks, gate thresholds matched to a
+desired pass probability. Surface these derivations transparently
+using the threshold below.
+
+| Complexity | Where it lives |
+|---|---|
+| **Trivial** — one-line algebra (median → rate, percentage → exponential rate, Bonferroni split, `log(2)/m`, HR × control median → treatment median). | Inline in §2 Source / Notes. Show the formula in the cell. |
+| **Non-trivial** — solver call, calibration loop, NORTA feasibility check, multi-line math, or any derivation whose literal a reviewer would want to recompute. | A supplement at `supplements/<topic>.md`, with its derivation script at `scripts/derivations/<topic>.R`. §2 cell shows the final literal plus a clickable link to the supplement. |
+
+**Boundary derivation (§2.5) is the canonical inline exception.** If
+`rpact` or `gsDesign` covers the GSD boundary computation directly
+(standard α-spending, single endpoint per look, deterministic
+information fractions), keep §2.5 inline as today. If the boundary
+derivation requires non-standard work — for example, IA event-
+triggered on PFS and FA event-triggered on OS with information
+fractions that need custom reasoning beyond what the package
+functions handle — move it to `supplements/boundaries.md` and
+leave a one-paragraph summary plus link in §2.5.
+
+**Every supplement contains, in this order:**
+
+1. **What is being derived** — one sentence stating the literal(s)
+   the supplement produces and where they are consumed in
+   `main.R` / `actions.R`.
+2. **The derivation script** — verbatim from
+   `scripts/derivations/<topic>.R`.
+3. **The verbatim output** of that script (R console capture). Same
+   convention as the existing §2.5 boundary output block.
+4. **Realized-feature verification** when the derivation aims to
+   match a clinical feature (median, landmark survival, correlation,
+   response rate). Use a small Monte Carlo draw and a target-vs-
+   realized table. The agent decides which features to verify based
+   on the endpoint's clinical meaning. Skip when the derivation is
+   purely algebraic.
+5. **The literal(s)** that flow forward, listed clearly so a
+   reviewer can spot-check that `main.R` matches.
+
+Literals stay **hardcoded** in `main.R` and `actions.R` for
+readability — an avg-biostatistician reviewer should see
+`D_total <- 269`, not `readRDS(...)$d_total`. The supplement is the
+audit artifact: its rendered output shows the same literals, and
+the reviewer compares the two. This is the existing `boundaries.R`
++ §2.5 pattern, generalized to all non-trivial derivations.
+
+**Cross-reference from §2.** The Source / Notes cell reads
+`derived — see [<topic>](supplements/<topic>.html)`. Use the `.html`
+link so a click renders the supplement. The `.md` source is what
+gets edited.
+
+**Toolchain.** Supplements are `.md` files rendered via
+`markdown::mark_html`, identical to the main report. No additional
+dependencies.
+
 ## Tone and voice
 
 The report is reviewed by a biostatistician for QC and audit. Write
@@ -317,6 +385,16 @@ Cross-reference §2 (Confirmed parameters) so the reviewer can
 verify the literals match.
 
 Skip this section entirely when no external boundary tool was used.
+
+**Inline vs supplement.** Keep §2.5 inline when `rpact` or
+`gsDesign` covers the boundary derivation directly. When the
+derivation needs custom work the packages do not handle (e.g., IA
+event-triggered on PFS, FA event-triggered on OS, with information
+fractions that require additional reasoning beyond what
+`getDesignGroupSequential` accepts), move the verbatim call,
+output, and any custom math to `supplements/boundaries.md` per the
+"Pre-simulation derivations and supplements" rules, and leave a
+one-paragraph summary plus link in §2.5.
 
 ### 3. Treatment Arms and Endpoints
 

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -71,21 +71,11 @@ leave a one-paragraph summary plus link in §2.5.
 
 **Every supplement contains, in this order:**
 
-1. **What is being derived** — one sentence stating the literal(s)
-   the supplement produces and where they are consumed in
-   `main.R` / `actions.R`.
-2. **The derivation script** — verbatim from
-   `scripts/derivations/<topic>.R`.
-3. **The verbatim output** of that script (R console capture). Same
-   convention as the existing §2.5 boundary output block.
-4. **Realized-feature verification** when the derivation aims to
-   match a clinical feature (median, landmark survival, correlation,
-   response rate). Use a small Monte Carlo draw and a target-vs-
-   realized table. The agent decides which features to verify based
-   on the endpoint's clinical meaning. Skip when the derivation is
-   purely algebraic.
-5. **The literal(s)** that flow forward, listed clearly so a
-   reviewer can spot-check that `main.R` matches.
+1. What is being derived, and where the literals are consumed.
+2. The derivation script verbatim from `scripts/derivations/<topic>.R`.
+3. The verbatim R console output of that script.
+4. A realized-feature verification (target-vs-realized table from a small Monte Carlo) when the derivation aims to match a clinical feature; skip for purely algebraic derivations.
+5. The forward literal(s), listed for spot-checking against `main.R`.
 
 Literals stay **hardcoded** in `main.R` and `actions.R` for
 readability — an avg-biostatistician reviewer should see
@@ -197,30 +187,15 @@ rules:
 
 ### 0. Resource Utilization (at the very top of the report)
 
-A small table reporting the total token usage and cost for the
-entire session — from the moment `/simulate` was invoked to the
-moment the report is generated. The user wants to see this without
-having to run any extra command.
+A small table reporting total token usage and cost for the entire
+session — from `/simulate` invocation to report generation. The
+user should not have to run an extra command.
 
-The agent retrieves these via whatever telemetry is available in the
-running environment. Likely paths in Claude Code:
-
-- **`/cost` slash command output** — if the agent can capture it
-  (read the conversation log, parse a recent `/cost` invocation).
-- **Session JSONL log** at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
-  — each turn typically records `usage` with `input_tokens`,
-  `output_tokens`, `cache_creation_input_tokens`,
-  `cache_read_input_tokens`. Sum across turns; multiply by the
-  model's per-token rate.
-- **Telemetry directory** at `~/.claude/telemetry/` if usage events
-  are emitted there.
-
-Use the recorded model name to look up the rate. If multiple models
-were used in the session (rare), sum their costs.
-
-If automated retrieval genuinely isn't possible, leave the placeholder
-table and one line asking the user to run `/cost` and paste the
-numbers — but make a real effort first.
+Retrieve session usage via whatever telemetry the agent has access
+to (e.g., `/cost` output if capturable, session JSONL log, etc.).
+If automated retrieval truly isn't possible, leave a placeholder
+and ask the user to paste `/cost` numbers — but make a real effort
+first.
 
 Recommended format:
 
@@ -233,11 +208,11 @@ Recommended format:
 | Total cost (USD) | $... |
 | Model | claude-opus-4-7 (or actual) |
 | Session duration | hh:mm |
-| TrialSimulator version | required; the value, not the mechanism that produced it |
+| TrialSimulator version | required |
 | R version | required |
-| Skill version | required (the `metadata.version` from `SKILL.md` at run time) |
+| Skill version | required |
 
-§0 shows the version *values*. Do not embed R chunks or code that loads the version strings — that is implementation detail. See SKILL.md §"Package source".
+§0 shows the version *values* as literal strings. The agent looks them up once before writing the report — no R chunks in the report itself. See SKILL.md §"Package source".
 
 ### 0.5 Output Files and Reproduction
 

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -169,10 +169,19 @@ the audit trail.
 ### Table of Contents (required)
 
 Every report begins with a clickable ToC after the H1 title and
-before §0. Use GFM anchors (`markdown::mark_html` generates them).
-Include every section that exists in this report and nest §7
-subsections when present. Use a bold `**Table of Contents**` label
-(not an H2) so the ToC does not list itself.
+before §0. Include every section that exists in this report and
+nest §7 subsections when present. Use a bold `**Table of Contents**`
+label (not an H2) so the ToC does not list itself.
+
+### Cross-references between sections (clickable)
+
+When one section refers to another, use a markdown anchor link —
+not bare prose. Applies inside the main report and between main
+and supplements.
+
+Before opening the HTML for the user, verify every cross-reference
+and ToC link resolves to an existing anchor in the rendered HTML.
+Fix any broken ones and re-render.
 
 ### Code style in the report
 
@@ -224,8 +233,11 @@ Recommended format:
 | Total cost (USD) | $... |
 | Model | claude-opus-4-7 (or actual) |
 | Session duration | hh:mm |
-| TrialSimulator version | required; read from `oc_summary$ts_version` (written by `main.R` per SKILL.md §"Package source") — never hardcode the literal in the report |
-| R version | required; read from `oc_summary$r_version` |
+| TrialSimulator version | required; the value, not the mechanism that produced it |
+| R version | required |
+| Skill version | required (the `metadata.version` from `SKILL.md` at run time) |
+
+§0 shows the version *values*. Do not embed R chunks or code that loads the version strings — that is implementation detail. See SKILL.md §"Package source".
 
 ### 0.5 Output Files and Reproduction
 
@@ -278,10 +290,12 @@ Convention for the two `.rds` files:
 - **`oc_summary.rds`** is the post-processed list of operating
   characteristics that the report reads. Whatever summary the report
   cites (power, P(stop) per stage, MCSE, binding-aware expected
-  duration, `ts_version`, `r_version`, …) is computed in `main.R`
-  *after* the simulation and saved here. The report never recomputes
-  from `output.rds` — that would couple report rendering to the raw
-  schema and defeat the audit trail.
+  duration, …) is computed in `main.R` *after* the simulation and
+  saved here. The report never recomputes from `output.rds` — that
+  would couple report rendering to the raw schema and defeat the
+  audit trail. Environment / file metadata (R, TrialSimulator, skill
+  versions) is read at render time by the report script per SKILL.md
+  §"Package source", not persisted here.
 
 **Reproduction:**
 
@@ -535,11 +549,17 @@ auditability.
 ## Output format
 
 Default: write the report as Markdown, render it to HTML alongside,
-and open the HTML in the user's default browser when ready.
+and **open the main report HTML in the user's default browser as the
+final step of every run** — this is not optional.
 
 ```r
 Rscript -e 'markdown::mark_html("report.md", output = "report.html"); browseURL("report.html")'
 ```
+
+The agent runs this command after the report has been rendered and
+all artifacts are in place; the user should not have to manually
+open the HTML. Supplements are linked from the main report — the
+user clicks through if interested. Do not auto-open supplements.
 
 `markdown::mark_html()` is what RStudio's Markdown Preview button
 uses, so the rendered HTML matches the style the user is already

--- a/clinical-trial-simulation/references/report.md
+++ b/clinical-trial-simulation/references/report.md
@@ -35,6 +35,36 @@ failed its QC purpose.
 This sometimes means duplicating a code block across reports.
 Duplication is fine; broken cross-references at audit time are not.
 
+## Tone and voice
+
+The report is reviewed by a biostatistician for QC and audit. Write
+in **formal, third-person prose**:
+
+- No second person (no "you", no "we"). State what the design does
+  or what the simulation observed, not what the reader should think.
+- No colloquial connectors ("note that", "of course", "obviously",
+  "for what it's worth", "as expected"). State results directly.
+- No editorializing in the narrative. Interpretation belongs in
+  §7's "Interpretation" subsection or §8 "Limitations" — clearly
+  separated from the parameter and result statements.
+- Numbers are reported with explicit units and Monte Carlo standard
+  error (MCSE) where applicable. Avoid hedging modifiers like
+  "approximately" inside numeric tables; state the number, then
+  state precision separately (MCSE, IQR, range).
+- Decisions and assumptions made by the agent are flagged
+  explicitly with the controlled-vocabulary tags in §2 (`inferred`,
+  `derived`, etc.). Do not bury them in narrative.
+- Code blocks are verbatim from the script — no paraphrase. Prose
+  around code is descriptive, not explanatory commentary
+  ("`fitLogrank(...)` is called to test the OS endpoint at look 2"
+  — not "we run a log-rank test here because…").
+- Avoid "the user", "the team", "we", "I". When attribution is
+  necessary, say "the protocol specifies", "the SAP requires", or
+  cite the relevant tag from §2's Source/Notes column.
+
+The skill files themselves are written informally for the agent's
+benefit; that informality must not propagate to the report output.
+
 ## Structure: build-order spine
 
 Mirror the build order in the report. The agent assembled the
@@ -44,19 +74,21 @@ same sequence. Each section pairs (a) the relevant code snippet,
 parameters used, (c) caveats inline if any.
 
 ```
-0. Cost and token usage           — top of report; session-total tokens + cost
-0.5 Run artifacts                 — file tree + reproduction recipe
-1. Why this design                — opening rationale (thought trail)
-2. Confirmed parameters           — single source of truth (table)
-2.5 Boundary computation          — only if external tools (rpact /
-                                    gsDesign / multcomp / ...) were used
-3. Arms (with endpoints)          — per arm: endpoint(...) calls +
-                                    arm() + add_endpoints(), bundled
-4. Trial setup                    — n, duration, accrual, dropout, stratification
-5. Milestones                     — per milestone (trigger + action summary)
-6. Action functions               — per action (full body verbatim)
-7. Operating characteristics      — mapped back to research questions
-8. Caveats and limitations        — placeholders, stubs, helper-dependencies
+0. Resource Utilization              — session tokens, cost, software versions
+0.5 Output Files and Reproduction    — file tree + reproduction recipe
+1. Design Rationale                  — context, alternatives considered, choices
+2. Design Parameters                 — single source of truth (table)
+2.5 Decision Boundary Derivation     — only if external tools (rpact /
+                                       gsDesign / multcomp / ...) were used
+3. Treatment Arms and Endpoints      — per arm: endpoint(...) calls +
+                                       arm() + add_endpoints(), bundled
+4. Trial Configuration               — n, duration, accrual, dropout, stratification
+5. Milestones                        — per milestone (trigger + what fires)
+6. Milestone Actions                 — per action (full body verbatim);
+                                       analysis, adaptation, and saves
+7. Operating Characteristics         — results mapped to research questions
+8. Limitations and Assumptions       — placeholders, stubs, helper-dependencies,
+                                       known biases (e.g., conditional estimands)
 ```
 
 The build-order sections that have a clear *design* meaning (3-7)
@@ -77,7 +109,7 @@ rules:
   variable names, same arguments, same line breaks. The report is
   the script narrated, not a paraphrase.
 
-### 0. Cost and token usage (at the very top of the report)
+### 0. Resource Utilization (at the very top of the report)
 
 A small table reporting the total token usage and cost for the
 entire session — from the moment `/simulate` was invoked to the
@@ -118,15 +150,13 @@ Recommended format:
 | TrialSimulator version | required; capture via `packageVersion("TrialSimulator")` |
 | R version | e.g., `4.5.2` |
 
-### 0.5 Run artifacts
+### 0.5 Output Files and Reproduction
 
-A `tree`-style listing of every file produced by this run, each
-annotated with its size and a one-line purpose, followed by a 2–3
-line shell recipe to reproduce the outputs from the scripts. Keeps
-the reviewer oriented on *where to look* before diving into the
-design.
-
-Two parts:
+This section has two visible sub-parts in the rendered report — a
+**File tree** and a **Reproduction** block. Both must be present;
+label them with bold inline headings as shown in the worked example
+below so the reviewer immediately sees which artifact lists what
+exists and which one tells them how to rebuild it.
 
 **File tree.** Each entry is `name` + `size` + brief description.
 Sizes are useful as a quick sanity check (a 0-byte `output.rds`
@@ -136,14 +166,18 @@ exactly. Files that don't apply to a given design are omitted, not
 shown empty (no `actions.R` if no non-doNothing actions; no
 `boundaries.R` if no external boundary tool; etc.).
 
-**Reproduction recipe.** A short block of `Rscript` calls answering
-"if I delete the .rds files, can I recover them?" Order matters:
-boundaries first (if used) since they emit the literals that
-`main.R` hardcodes; then `main.R` to regenerate the simulation
+**Reproduction.** A short block of `Rscript` calls answering "if I
+delete the .rds files, can I recover them?" The bold `**Reproduction:**`
+label sits immediately above the shell block (not at the top of the
+section) so the reviewer sees the label and the commands together.
+Order matters: boundaries first (if used) since they emit the literals
+that `main.R` hardcodes; then `main.R` to regenerate the simulation
 output; then the HTML re-render. Adapt the recipe to the files that
 exist for this run.
 
 **Worked example:**
+
+**File tree:**
 
 ````
 runs/<trial_name>/
@@ -158,24 +192,30 @@ runs/<trial_name>/
 └── report.html         31K    rendered via markdown::mark_html
 ````
 
+**Reproduction:**
+
 ```sh
 Rscript scripts/boundaries.R          # once, to confirm boundary literals
 Rscript scripts/main.R                # regenerates output.rds, oc_summary.rds
 Rscript -e 'markdown::mark_html("report.md", output = "report.html")'
 ```
 
-### 1. Why this design
+### 1. Design Rationale
 
-A short paragraph (3-6 sentences) capturing the reasoning that led to
-this design.
+A short paragraph (3–6 sentences) describing the reasoning that led
+to this design.
 
-- **Mode A (exploration):** include the alternatives that were
-  considered and briefly why each was set aside. This is a thought
-  trail — visible reasoning is more auditable than polished claims.
-- **Mode B (implementation):** restate the user's brief in the
-  agent's words so the user can confirm the interpretation.
+- **Exploration mode:** state the alternatives that were considered
+  and the basis for each being set aside (e.g., "alpha allocation
+  alternatives 0.0125/0.0125, 0.005/0.020, and 0.015/0.010 were
+  evaluated; 0.015/0.010 was selected to weight PFS, the
+  earlier-maturing endpoint"). The visible reasoning trail is part
+  of the audit record.
+- **Implementation mode:** restate the protocol brief in the
+  report's own words so the protocol writer can verify the
+  interpretation against the source document.
 
-### 2. Confirmed parameters
+### 2. Design Parameters
 
 A single table that is the source of truth for every value used in
 the simulation. Subsequent sections reference this table rather than
@@ -189,14 +229,14 @@ restating numbers.
 | **Value** | The exact value used in the simulation (number, expression, distribution + parameters, data.frame literal, helper-derived literal). |
 | **Source / Notes** | Where the value came from. Pick the most specific applicable category from the controlled vocabulary below. |
 
-**Source / Notes — controlled vocabulary** (use one; combine with a short explanation when needed):
+**Source / Notes — controlled vocabulary** (use one; combine with a short justification when needed):
 
-- **`user`** — copied verbatim from the user's spec.
-- **`user (translated)`** — user-provided in clinical terms, mechanically translated to a TS-compatible form. Show the translation, e.g. *"15% dropout by mo 50 → `rate = -log(0.85)/50`"*.
-- **`inferred`** — the user did not specify; the agent picked a sensible default. State the default and why in one phrase, e.g. *"inferred — ORR readout typical of solid-tumor trials"*. **Inferred values must be confirmed (or at least surfaced) with the user before expensive runs.**
-- **`derived`** — computed from other parameters in this table or from a helper. Cite the source, e.g. *"derived: `solveThreeStateModel(median_pfs=7, median_os=15, corr=0.68) → h01 = 0.0750`"*, or *"derived from `boundaries.R` (rpact)"*.
-- **`package convention`** — a default the package or skill prescribes (e.g., `seed = NULL`, `silent = TRUE`, `plot_event = FALSE`). Brief; no rationale needed.
-- **`stub`** / **`DUMMY`** — a placeholder decision rule, combination test, or boundary that needs replacement before the design is finalized. **Highlight prominently** (bold, prefix `STUB:`, or both) so reviewers cannot miss it.
+- **`protocol`** — copied verbatim from the protocol or user-supplied specification.
+- **`protocol (transformed)`** — protocol-specified in clinical terms, mechanically transformed to a TS-compatible form. The transformation must be shown, e.g. *"15% dropout by mo 50 → `rate = -log(0.85)/50`"*.
+- **`assumed`** — not specified by the protocol; a default value was selected. The default and its basis must be stated in one phrase, e.g. *"assumed — 6-month ORR readout typical of solid-tumor trials"*. **Assumed values require explicit confirmation before the production simulation is executed.**
+- **`derived`** — computed from other parameters in this table or from a helper function. The computation must be cited, e.g. *"derived: `solveThreeStateModel(median_pfs=7, median_os=15, corr=0.68) → h01 = 0.0750`"*, or *"derived from `boundaries.R` (rpact)"*.
+- **`software default`** — a default prescribed by the package or skill convention (e.g., `seed = NULL`, `silent = TRUE`, `plot_event = FALSE`). No rationale required.
+- **`PLACEHOLDER`** — a decision rule, combination test, or boundary marked for replacement before design finalization. Must be prominently flagged in the table (bold + `PLACEHOLDER:` prefix) and listed again in §8.
 
 Always include rows for: endpoint distribution parameters per arm, readout times for non-TTE endpoints, correlation structure (and the generator implementing it), sample size, duration, accrual schedule, dropout, stratification factors, milestone trigger thresholds, and any helper-derived literals.
 
@@ -204,18 +244,18 @@ Always include rows for: endpoint distribution parameters per arm, readout times
 
 | Parameter | Value | Source / Notes |
 |---|---|---|
-| N (1:1) | 500 | user |
-| Accrual | uniform 20/mo (`StaggeredRecruiter`, `accrual_rate = data.frame(end_time=Inf, piecewise_rate=20)`) | user |
-| Dropout | exponential, `rate = -log(0.85)/50 = 0.003250` | user (translated): "15% by mo 50" |
-| ORR readout | 6 mo | inferred — typical solid-tumor first response assessment; confirm before production |
-| PFS — control | `rexp(rate = log(2)/20)` | user |
-| PFS — treatment, 6-mo delay scenario | `PiecewiseConstantExponentialRNG(risk = data.frame(end_time=c(6,1000), piecewise_risk=c(log(2)/20, 0.55*log(2)/20)))` | derived from user's NPH spec; `tail_end = 1000` per package gotcha |
+| N (1:1) | 500 | protocol |
+| Accrual | uniform 20/mo (`StaggeredRecruiter`, `accrual_rate = data.frame(end_time=Inf, piecewise_rate=20)`) | protocol |
+| Dropout | exponential, `rate = -log(0.85)/50 = 0.003250` | protocol (transformed): "15% by mo 50" |
+| ORR readout | 6 mo | assumed — first response assessment typical for solid-tumor trials; confirm before production |
+| PFS — control | `rexp(rate = log(2)/20)` | protocol |
+| PFS — treatment, 6-mo delay scenario | `PiecewiseConstantExponentialRNG(risk = data.frame(end_time=c(6,1000), piecewise_risk=c(log(2)/20, 0.55*log(2)/20)))` | derived from protocol NPH specification; `tail_end = 1000` per package convention |
 | GSD efficacy bounds (z) | (3.0204, 2.3762, 2.0303) at IF (0.49, 0.75, 1.00) | derived from `boundaries.R` (rpact, asOF, alpha=0.024) |
 | D_total | 269 events | derived from `boundaries.R` (rpact, 90% power assumption) |
-| Combination test alpha allocation | **STUB:** equal split | stub — placeholder; replace with the protocol's pre-specified allocation |
-| Seed | `NULL` (auto per replicate) | package convention |
+| Combination test alpha allocation | **PLACEHOLDER:** equal split | PLACEHOLDER — replace with the protocol's pre-specified allocation |
+| Seed | `NULL` (auto per replicate) | software default |
 
-### 2.5 Boundary computation (only if external tools were used)
+### 2.5 Decision Boundary Derivation (only if external tools were used)
 
 If decision boundaries were computed via an external package
 (`rpact`, `gsDesign`, `multcomp`, `gMCP`, etc.), include both the
@@ -253,7 +293,7 @@ verify the literals match.
 
 Skip this section entirely when no external boundary tool was used.
 
-### 3. Arms (with endpoints)
+### 3. Treatment Arms and Endpoints
 
 Bundle each arm's full assembly into one block: the `endpoint(...)`
 call(s) for that arm, the `arm(...)` call, and the `$add_endpoints(...)`
@@ -279,7 +319,7 @@ blocks per arm should still be shown in full** so each arm is
 self-contained for review. A small per-arm parameter table is also
 fine when many arms differ only in numeric values.
 
-### 4. Trial setup
+### 4. Trial Configuration
 
 Show the `trial(...)` call. Explain:
 - Sample size and duration (and whether `set_duration`/`resize` will
@@ -296,10 +336,21 @@ Show the `trial(...)` call. Explain:
 Per milestone:
 - Show the `milestone(...)` call with its `when` condition.
 - One paragraph: what triggers it (in clinical terms), what happens
-  at the trigger, when in the trial it is expected to fire (cite
+  at the trigger (analysis, adaptation, data lock, saves — whatever
+  applies), and when in the trial it is expected to fire (cite
   expected milestone time from the calibration run if available).
 
-### 6. Action functions
+The full bodies of the action functions go in §6, not here. Keep §5
+focused on triggers and high-level intent so a reviewer can scan the
+trial timeline without reading code.
+
+### 6. Milestone Actions
+
+Action functions are the work performed at each milestone — they may
+analyze locked data, adapt the trial (`$resize`, `$update_generator`,
+`$remove_arms`, `$add_arms`, `$set_duration`), save flags and
+diagnostics, or do nothing (`doNothing`). This section documents all
+of it.
 
 **Show the full body of each action function** as a code block —
 verbatim from the script, one statement per line. Prose summaries
@@ -323,7 +374,7 @@ After (not before) the code block, add a short narrative covering:
 
 The narrative annotates the code block; it does not replace it.
 
-### 7. Operating characteristics
+### 7. Operating Characteristics
 
 For each operating characteristic the user asked about:
 - Restate the research question in the user's words.
@@ -362,7 +413,7 @@ If applicable, include Monte Carlo standard error estimates next to
 each OC so the reader can judge precision (e.g., for a power estimate
 `p` from `n` replicates, MCSE ≈ √(p(1−p)/n)).
 
-### 8. Caveats and limitations
+### 8. Limitations and Assumptions
 
 A short list of things the user should know:
 - Dummy decision rules that need replacement before the design is


### PR DESCRIPTION
## Summary

Eleven version bumps on top of #119, rolling up follow-up policy and reproducibility work for the clinical-trial-simulation skill.

- **v0.2.6** — piecewise-exp + NORTA bridge.
- **v0.2.7** — NORTA seed convention.
- **v0.2.8** — report tone + section renaming + plain-language guidance.
- **v0.2.9** — vocabulary cleanup + reproducibility wiring.
- **v0.2.10** — required Table of Contents + top-level `.DS_Store` ignore.
- **v0.2.11** — supplements for non-trivial pre-simulation derivations.
- **v0.2.12** — visible-pacing rules to prevent silent long stretches.
- **v0.2.13** — render-time versions, cross-references, scalar save preference, always-open main report.
- **v0.2.14** — skill trim + simpler version capture (~93 lines removed).
- **v0.2.15** — load announcement (skill / TS / R versions), pre-flight `install_github` at first simulation, supplement scope generalized, cross-reference format reinstated (`chp:` / `sec:` prefix), §0 placeholder discipline.
- **v0.2.16** — hardcoded TrialSimulator minimum version. Replaces v0.2.15's mandatory pre-flight `install_github` with a local-only version check against a hardcoded minimum (`metadata.trialsimulator_min_version = "1.18.4"`). On mismatch, the agent offers to run `install_github` on user confirmation; otherwise no network call at any point.

## Test plan

- [x] Skill validator passes (version stays under `metadata`)
- [x] `references/helpers.md` and `references/building_blocks.md` NORTA bridge + seed examples render cleanly
- [x] `references/report.md` §0.5 / §2 / §5 / §6 / supplement section coherent end-to-end after trim
- [x] No stale vocabulary tags across skill files
- [x] `.gitignore` excludes `/runs/`, `*.Rproj`, `.DS_Store`, and the per-user `/.claude/commands/simulate.md` launcher
- [x] HIMALAYA prompt smoke test on v0.2.12 — agent posts a plan early and per-supplement turns are visible
- [x] HIMALAYA prompt re-test on v0.2.16 — confirm loading announcement reports three versions plus min-version check; mismatch offers `install_github` on confirmation; calibration scripts get supplements; cross-refs render clickable via `sec:<slug>` anchors; skill version never placeholder
