### PR TITLE
issue-to-eval: import benchmark evals for issues #137, #139, #141, #142

### DIFF
--- a/_automation/evals/github-issue-137.json
+++ b/_automation/evals/github-issue-137.json
@@ -1,0 +1,27 @@
+{
+  "id": "github-issue-137",
+  "prompt": "I need to build an ADAE dataset for a Phase 3 safety analysis. I have the\nstandard pharmaverse SDTM AE domain and a completed ADSL. Please derive all\nrequired analysis variables: analysis dates, study days, the treatment-emergent\nflag, severity, seriousness, causality, and outcome. Use a 30-day post-treatment\nwindow for TRTEMFL.",
+  "expected_output": "Executable R script using `{admiral}` that produces a valid ADAE dataset from\n`pharmaversesdtm::ae` and `pharmaverseadam::adsl`. The script should execute\nwithout errors and produce an output dataset with one record per AE per subject.\n\nKey variables expected in the output:\n\n| Variable | Source / derivation |\n|---|---|\n| ASTDT, ASTDTF | `derive_vars_dt()` from AESTDTC, imputation = \"first\" |\n| AENDT, AENDTF | `derive_vars_dt()` from AEENDTC, imputation = \"last\" |\n| ASTDY, AENDY | `derive_vars_dy()` relative to TRTSDT |\n| TRTEMFL | `derive_var_trtemfl()`, end_window = 30 (annotated) |\n| AESEV | Carried from AE.AESEV |\n| AESEVN | Integer 1/2/3 via `case_when()` |\n| AESER, AESDTH | Recoded to \"Y\"/NA |\n| AEOUT, AEREL, AEACN | Carried from AE with controlled terminology alignment |\n\nThe script must end with a check that all required variables are present and\nthat the output row count is at least equal to the input AE row count.",
+  "files": [],
+  "assertions": [
+    "`library()` calls include at minimum `admiral`, `dplyr`, and `lubridate`",
+    "DOMAIN is removed from AE before any merge or derivation step",
+    "ADSL is merged using `derive_vars_merged()` with an explicit `select()` limiting to required variables \u2014 not `select(everything())`",
+    "ASTDT and AENDT are derived via `derive_vars_dt()`, not `as.Date()` applied directly to a DTC variable",
+    "ASTDTF and AENDTF are present in the output dataset",
+    "ASTDY and AENDY are derived via `derive_vars_dy()`, not manual arithmetic (`ASTDT - TRTSDT + 1` or similar)",
+    "TRTEMFL is derived via `derive_var_trtemfl()` \u2014 not a manual `if_else()` or `case_when()` date comparison",
+    "The `end_window` argument in `derive_var_trtemfl()` is accompanied by a `# REVIEW:` comment",
+    "TRTEMFL values are \"Y\" or NA \u2014 no \"N\" values present",
+    "AESER and AESDTH values are \"Y\" or NA \u2014 no \"N\" values present",
+    "AESEVN is derived as an integer via `case_when()` from character AESEV \u2014 not by coercing AESEV directly to numeric",
+    "A `stopifnot(nrow(ae) > 0)` or equivalent assertion is present at data load",
+    "A required-variable presence check using `stop()` or `stopifnot()` is present before the final dataset",
+    "`nrow(adae) >= nrow(ae)` \u2014 output row count is at least equal to input AE row count",
+    "The script runs end-to-end without errors against `pharmaversesdtm::ae` and `pharmaverseadam::adsl`"
+  ],
+  "language": "R",
+  "target_skills": [
+    "admiral-adae"
+  ]
+}

--- a/_automation/evals/github-issue-139.json
+++ b/_automation/evals/github-issue-139.json
@@ -1,0 +1,10 @@
+{
+  "id": "github-issue-139",
+  "prompt": "A PD-(L)1\u2013LAG Inspired Phase 3 Design\n\nClinical context:\n\nYou are a statistician in **January 2022** designing a Phase 3 trial for a novel **Drug A + Drug B** combination in **previously untreated unresectable locally advanced or metastatic melanoma**.\n\nThis is a **PD-(L)1\u2013LAG inspired** design.\n\n- **Drug A**: novel immune-checkpoint antibody targeting LAG biology.\n- **Drug B**: sponsor's PD-(L)1 backbone therapy.\n- **Drug C**: external standard-of-care PD-(L)1 active control.\n\nEarly single-arm Phase 1 data suggest promising activity for Drug A + Drug B, but evidence is limited. A competing PD-(L)1\u2013LAG regimen has shown positive randomized PFS data versus PD-(L)1 monotherapy, supporting the mechanism but raising the bar for differentiation.\n\nPrimary endpoint: **PFS by blinded independent central review**.\n\nOverall one-sided type I error: **0.025**.\n\nDo not use any future Phase 3 results or post-Jan 2022 information.",
+  "expected_output": "Provide:\n\n- Recommended randomization ratio and sample size by arm.\n- Recommended primary comparison strategy.\n- Multiplicity strategy and alpha allocation.\n- PFS event targets and timeline projection.\n- Approximate power under HR **0.70, 0.72, 0.75, 0.80, and 0.85**.\n- Sensitivity to Drug C median PFS assumptions.\n- IA/FA timing, information fractions, alpha spent, Z or p-value boundaries, and approximate HR boundaries if possible.\n- Final recommendation on whether approximately **1,500 patients** is sufficient.",
+  "files": [],
+  "assertions": [],
+  "target_skills": [
+    "group-sequential-design"
+  ]
+}

--- a/_automation/evals/github-issue-141.json
+++ b/_automation/evals/github-issue-141.json
@@ -1,0 +1,33 @@
+{
+  "id": "github-issue-141",
+  "prompt": "I need to create two outputs from the pharmaversesdtm package:\n\n1. Add baseline vital sign variables (HEIGHTBL, WEIGHTBL, BMIBL) to an existing ADSL dataset using data from the VS domain.\n2. Create a full ADVS BDS ADaM dataset from the VS domain, including analysis values, baseline flags, change from baseline, and normal range indicators.\n\nUse the admiral R package for all derivations. Input data should come from pharmaversesdtm. The reference output for ADVS is pharmaverseadam::advs.",
+  "expected_output": "Two R script outputs:\n\n1. **ADSL** — the input ADSL dataset augmented with HEIGHTBL, WEIGHTBL, and BMIBL, each sourced from the corresponding baseline VS record (VSBLFL == \"Y\").\n2. **ADVS** — a BDS ADaM dataset containing one record per subject per parameter per visit, with PARAMCD, PARAM, AVAL, AVALC, ADT, ADY, ABLFL, BASE, CHG, PCHG, and ANRIND populated. Reference: `pharmaverseadam::advs`.",
+  "files": [
+    "`pharmaversesdtm::vs` — Vital Signs SDTM domain (input)",
+    "`pharmaversesdtm::dm` — Demographics SDTM domain (for subject spine)",
+    "`pharmaverseadam::adsl` — Subject-level ADaM (for merging into ADVS and for ADSL augmentation)",
+    "`pharmaverseadam::advs` — Reference output for ADVS",
+    "All datasets are available via the `pharmaversesdtm` and `pharmaverseadam` R packages."
+  ],
+  "assertions": [
+    "The script must use the `admiral` R package for all ADaM derivations.",
+    "The ADSL output must include the variables HEIGHTBL, WEIGHTBL, and BMIBL.",
+    "HEIGHTBL must be derived from baseline VS records where VSTESTCD == \"HEIGHT\" and VSBLFL == \"Y\" using `derive_vars_merged()`.",
+    "WEIGHTBL must be derived from baseline VS records where VSTESTCD == \"WEIGHT\" and VSBLFL == \"Y\" using `derive_vars_merged()`.",
+    "BMIBL must be derived from baseline VS records where VSTESTCD == \"BMI\" and VSBLFL == \"Y\", or computed from HEIGHTBL and WEIGHTBL.",
+    "The ADVS dataset must contain at minimum the columns: USUBJID, PARAMCD, PARAM, AVAL, AVALC, ADT, ADY, ABLFL, BASE, CHG, PCHG, ANRIND.",
+    "ADT must be derived from VSDTC using an admiral date derivation function (e.g., `derive_vars_dt()`).",
+    "ADY must be derived as study day relative to TRTSDT (or reference start date) using `derive_vars_dy()`.",
+    "ABLFL must equal \"Y\" only for the designated baseline record per subject per parameter, and must be NA otherwise.",
+    "BASE must equal AVAL for records where ABLFL == \"Y\", and must be the baseline AVAL carried to all other records for the same subject and parameter.",
+    "CHG must equal AVAL - BASE for numeric parameters (where BASE is non-missing).",
+    "PCHG must equal 100 * CHG / BASE for numeric parameters (where BASE is non-zero and non-missing).",
+    "ANRIND must be populated as \"LOW\", \"NORMAL\", or \"HIGH\" based on ANRLO and ANRHI reference ranges from the VS domain.",
+    "The script must run to completion without errors using pharmaversesdtm input data.",
+    "The structure of the ADVS output (variable names, number of records) must be comparable to `pharmaverseadam::advs`."
+  ],
+  "language": "R",
+  "target_skills": [
+    "admiral-adsl"
+  ]
+}

--- a/_automation/evals/github-issue-142.json
+++ b/_automation/evals/github-issue-142.json
@@ -1,0 +1,33 @@
+{
+  "id": "github-issue-142",
+  "prompt": "I need to create two outputs from the pharmaversesdtm package:\n\n1. Add baseline vital sign variables (HEIGHTBL, WEIGHTBL, BMIBL) to an existing ADSL dataset using data from the VS domain.\n2. Create a full ADVS BDS ADaM dataset from the VS domain, including analysis values, baseline flags, change from baseline, and normal range indicators.\n\nUse the admiral R package for all derivations. Input data should come from pharmaversesdtm. The reference output for ADVS is pharmaverseadam::advs.",
+  "expected_output": "Two R script outputs:\n\n1. **ADSL** — the input ADSL dataset augmented with HEIGHTBL, WEIGHTBL, and BMIBL, each sourced from the corresponding baseline VS record (VSBLFL == \"Y\").\n2. **ADVS** — a BDS ADaM dataset containing one record per subject per parameter per visit, with PARAMCD, PARAM, AVAL, AVALC, ADT, ADY, ABLFL, BASE, CHG, PCHG, and ANRIND populated. Reference: pharmaverseadam::advs.",
+  "files": [
+    "pharmaversesdtm::vs — Vital Signs SDTM domain (input)",
+    "pharmaversesdtm::dm — Demographics SDTM domain (for subject spine)",
+    "pharmaverseadam::adsl — Subject-level ADaM (for merging into ADVS and for ADSL augmentation)",
+    "pharmaverseadam::advs — Reference output for ADVS",
+    "All datasets are available via the pharmaversesdtm and pharmaverseadam R packages."
+  ],
+  "assertions": [
+    "The script must use the admiral R package for all ADaM derivations.",
+    "The ADSL output must include the variables HEIGHTBL, WEIGHTBL, and BMIBL.",
+    "HEIGHTBL must be derived from baseline VS records where VSTESTCD == \"HEIGHT\" and VSBLFL == \"Y\" using derive_vars_merged().",
+    "WEIGHTBL must be derived from baseline VS records where VSTESTCD == \"WEIGHT\" and VSBLFL == \"Y\" using derive_vars_merged().",
+    "BMIBL must be derived from baseline VS records where VSTESTCD == \"BMI\" and VSBLFL == \"Y\", or computed from HEIGHTBL and WEIGHTBL.",
+    "The ADVS dataset must contain at minimum the columns: USUBJID, PARAMCD, PARAM, AVAL, AVALC, ADT, ADY, ABLFL, BASE, CHG, PCHG, ANRIND.",
+    "ADT must be derived from VSDTC using an admiral date derivation function (e.g., derive_vars_dt()).",
+    "ADY must be derived as study day relative to TRTSDT (or reference start date) using derive_vars_dy().",
+    "ABLFL must equal \"Y\" only for the designated baseline record per subject per parameter, and must be NA otherwise.",
+    "BASE must equal AVAL for records where ABLFL == \"Y\", and must be the baseline AVAL carried to all other records for the same subject and parameter.",
+    "CHG must equal AVAL - BASE for numeric parameters (where BASE is non-missing).",
+    "PCHG must equal 100 * CHG / BASE for numeric parameters (where BASE is non-zero and non-missing).",
+    "ANRIND must be populated as \"LOW\", \"NORMAL\", or \"HIGH\" based on ANRLO and ANRHI reference ranges from the VS domain.",
+    "The script must run to completion without errors using pharmaversesdtm input data.",
+    "The structure of the ADVS output (variable names, number of records) must be comparable to pharmaverseadam::advs."
+  ],
+  "language": "R",
+  "target_skills": [
+    "admiral-adsl"
+  ]
+}


### PR DESCRIPTION
## Summary

Ran the `issue-to-eval` skill against the live GitHub issues labeled `benchmark` (30 open). Four new evaluation files are produced on this branch; every other open benchmark issue parses identically to what is already on disk.

### Issues imported (new)

| Issue | Skill | Title |
|---|---|---|
| #137 | admiral-adae | basic-teae: standard TEAE derivation with complete pharmaverse data |
| #139 | group-sequential-design | Four-arm design to test superiority, dose, and individual component contribution |
| #141 | admiral-adsl | ADVS BDS ADaM + ADSL baseline vital sign variables |
| #142 | admiral-adsl | ADVS BDS ADaM + ADSL baseline vital sign variables (duplicate prompt, plain-text formatting) |

### Skipped / no change

- Already up to date: #2, #3, #21, #22, #23, #24, #27, #36, #37, #38, #39, #40, #60, #69, #74, #91, #103, #104, #107, #109, #113, #118, #126, #128, #132, #133.
- #108 skipped: issue body has empty Skills/Query/Expected Output/Assertions sections.
- Empty-rubric warnings on #3, #126, and #139 (issue body has an empty `## Rubric Criteria (Assertions)` section) were preserved — they reflect the upstream issue content.

## Notes

- The `gh` CLI is unavailable in this environment, so the sync was run by feeding GitHub MCP issue bodies through `_automation/issue-to-eval/scripts/import_issue_eval.parse_issue_markdown` + `save_to_evals` directly. The MCP returns HTML-encoded text (e.g. `&#39;`, `&#34;`), so bodies are normalized via `html.unescape` before parsing to keep the on-disk evals byte-identical with prior `gh`-based runs.

## Test plan

- [ ] Re-run `python3 _automation/issue-to-eval/scripts/sync_benchmarks.py` after this PR merges and confirm every parseable issue reports **Skipped** (up to date).
- [ ] `_automation/evals/github-issue-137.json` carries `target_skills: ["admiral-adae"]`, `language: "R"`, and 15 rubric assertions.
- [ ] `_automation/evals/github-issue-139.json` carries `target_skills: ["group-sequential-design"]` and the four-arm PD-(L)1–LAG prompt.
- [ ] `_automation/evals/github-issue-141.json` and `_automation/evals/github-issue-142.json` each carry `target_skills: ["admiral-adsl"]`, `language: "R"`, and 15 rubric assertions for the ADVS BDS derivation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVqvWzpMsordjADR3c5FHy)_