### PR TITLE
issue-to-eval: import benchmark evals for issues #147, #148, #149

### DIFF
--- a/_automation/evals/github-issue-147.json
+++ b/_automation/evals/github-issue-147.json
@@ -1,0 +1,21 @@
+{
+  "id": "github-issue-147",
+  "prompt": "Using the pharmaversesdtm CDISC Pilot Study VS domain, derive an ADaM\nBDS Findings dataset (ADVS) for vital signs parameters.\n\nParameter mapping:\n- SYSBP  \u2192 \"Systolic Blood Pressure (mmHg)\",  PARAMN = 1\n- DIABP  \u2192 \"Diastolic Blood Pressure (mmHg)\", PARAMN = 2\n- PULSE  \u2192 \"Pulse Rate (beats/min)\",           PARAMN = 3\n- WEIGHT \u2192 \"Weight (kg)\",                      PARAMN = 4\n- HEIGHT \u2192 \"Height (cm)\",                      PARAMN = 5\n- BMI    \u2192 \"Body Mass Index (kg/m^2)\",         PARAMN = 6\n\nBaseline definition: the last non-missing record on or before TRTSDT\nper subject per parameter (ADT <= TRTSDT, !is.na(AVAL)).\n\nANL01FL: the last on-treatment non-missing non-DTYPE record per subject\nper parameter per analysis visit (ADT >= TRTSDT, !is.na(AVAL),\nis.na(DTYPE)).\n\nNormal range indicators (ANRIND): \"LOW\" / \"NORMAL\" / \"HIGH\" based on\nANRLO and ANRHI sourced from the VS domain (VSSTNRLO, VSSTNRHI).\n\nInclude at minimum: STUDYID, USUBJID, PARAMCD, PARAM, PARAMN, AVISIT,\nAVISITN, ADT, ADTF, ADY, AVAL, AVALC, AVALU, ABLFL, BASE, BASEC,\nCHG, PCHG, ANRLO, ANRHI, ANRIND, ANL01FL, TRTSDT, TRTEDT,\nTRT01P, TRT01PN, TRT01A, TRT01AN, SAFFL, ITTFL.",
+  "expected_output": "Executable R code producing an ADVS dataset with one record per subject\nper parameter per analysis visit that matches pharmaverseadam::advs on\nkey variables (ADT, AVAL, BASE, CHG, ABLFL, ANRIND per USUBJID /\nPARAMCD / AVISIT).",
+  "files": [
+    "Input data loaded directly from the {pharmaversesdtm} and",
+    "{pharmaverseadam} R packages (CDISC Pilot Study).",
+    "```r",
+    "library(pharmaversesdtm)",
+    "library(pharmaverseadam)",
+    "vs   <- pharmaversesdtm::vs",
+    "adsl <- pharmaverseadam::adsl",
+    "ref  <- pharmaverseadam::advs",
+    "```"
+  ],
+  "assertions": [],
+  "language": "R",
+  "target_skills": [
+    "admiral-bds"
+  ]
+}

--- a/_automation/evals/github-issue-148.json
+++ b/_automation/evals/github-issue-148.json
@@ -1,0 +1,11 @@
+{
+  "id": "github-issue-148",
+  "prompt": "Using the pharmaversesdtm CDISC Pilot Study AE domain and a completed\nADSL, derive an ADaM Adverse Events Analysis Dataset (ADAE) for a\nPhase 3 safety analysis.\n\nDerive all required analysis variables: analysis dates, study days,\nthe treatment-emergent adverse event flag, severity, seriousness,\ncausality, and outcome. Use a 30-day post-treatment window for TRTEMFL.\n\nInput data must be loaded directly from the pharmaverse R packages:\n\n```r\nlibrary(pharmaversesdtm)\nlibrary(pharmaverseadam)\nae   <- pharmaversesdtm::ae    # 1,191 records, CDISC Pilot Study\nadsl <- pharmaverseadam::adsl  # 306 subjects\n```\n\nDo not generate synthetic or simulated data. Scripts that construct\nAE or ADSL records from scratch will fail the benchmark.",
+  "expected_output": "Executable R script using {admiral} that produces a valid ADAE dataset\nfrom pharmaversesdtm::ae and pharmaverseadam::adsl. The script should\nexecute without errors and produce one record per AE per subject.\n\n| Variable | Source / derivation |\n|---|---|\n| ASTDT, ASTDTF | derive_vars_dt() from AESTDTC, date_imputation = \"first\" |\n| AENDT, AENDTF | derive_vars_dt() from AEENDTC, date_imputation = \"last\" |\n| ASTDY, AENDY | derive_vars_dy() relative to TRTSDT |\n| TRTEMFL | derive_var_trtemfl(), end_window = 30 (annotated) |\n| AESEV | Carried from AE.AESEV |\n| AESEVN | Integer 1/2/3 mapped from AESEV |\n| AESER, AESDTH | Recoded to \"Y\"/NA |\n| AEOUT, AEREL, AEACN | Carried from AE with controlled terminology alignment |\n\nNote: pharmaversesdtm::ae does not contain AETOXGR. The AETOXGR\nderivation should be commented out or omitted; its absence should\nnot cause the script to error.",
+  "files": [],
+  "assertions": [],
+  "language": "R",
+  "target_skills": [
+    "admiral-adae"
+  ]
+}

--- a/_automation/evals/github-issue-149.json
+++ b/_automation/evals/github-issue-149.json
@@ -1,0 +1,11 @@
+{
+  "id": "github-issue-149",
+  "prompt": "Using the pharmaversesdtm CDISC Pilot Study LB domain and a completed\nADSL, derive an ADaM BDS Findings dataset (ADLB) for laboratory values.\n\nInput data must be loaded directly from the pharmaverse R packages:\n\n```r\nlibrary(pharmaversesdtm)\nlibrary(pharmaverseadam)\nlb   <- pharmaversesdtm::lb\nadsl <- pharmaverseadam::adsl  # 306 subjects\n```\n\nDo not generate synthetic or simulated data. Scripts that construct\nLB or ADSL records from scratch will fail the benchmark.\n\nParameter scope: include all LBTESTCD values present in\npharmaversesdtm::lb. PARAMCD and PARAM should be mapped from a\nspec-driven lookup table, not hardcoded case_when() chains.\n\nBaseline definition: the last non-missing record on or before TRTSDT\nper subject per parameter (ADT <= TRTSDT, !is.na(AVAL)).\n\nANL01FL: the last on-treatment non-missing non-DTYPE record per subject\nper parameter per analysis visit (ADT >= TRTSDT, !is.na(AVAL),\nis.na(DTYPE)).\n\nNormal range indicators (ANRIND): \"LOW\" / \"NORMAL\" / \"HIGH\" based on\nANRLO and ANRHI sourced from the LB domain (LBSTNRLO, LBSTNRHI).\n\nInclude at minimum: STUDYID, USUBJID, PARAMCD, PARAM, PARAMN, AVISIT,\nAVISITN, ADT, ADTF, ADY, AVAL, AVALC, AVALU, ABLFL, BASE, BASEC,\nCHG, PCHG, ANRLO, ANRHI, ANRIND, BNRIND, ANL01FL, TRTSDT, TRTEDT,\nTRT01P, TRT01PN, TRT01A, TRT01AN, SAFFL, ITTFL.",
+  "expected_output": "Executable R code producing an ADLB dataset with one record per subject\nper parameter per analysis visit that matches pharmaverseadam::adlb on\nkey variables (ADT, AVAL, BASE, CHG, ABLFL, ANRIND per USUBJID /\nPARAMCD / AVISIT).",
+  "files": [],
+  "assertions": [],
+  "language": "R",
+  "target_skills": [
+    "admiral-bds"
+  ]
+}


### PR DESCRIPTION
## Summary

Ran the `issue-to-eval` skill against the live GitHub issues labeled `benchmark` (35 total). Three new evaluation files were produced; every other issue parses identically to what is already on disk.

### Issues imported (new)

| Issue | Skill | Title |
|---|---|---|
| #147 | admiral-bds | ADVS derivation from pharmaversesdtm — BDS Findings (vital signs) |
| #148 | admiral-adae | ADAE derivation from pharmaversesdtm — safety analysis |
| #149 | admiral-bds | ADLB derivation from pharmaversesdtm — BDS Findings (laboratory values) |

### Skipped / no change

- Already up to date (31 issues): #2, #3, #21, #22, #23, #24, #27, #36, #37, #38, #39, #40, #60, #69, #74, #91, #103, #104, #107, #109, #113, #118, #124, #126, #128, #132, #133, #137, #139, #141, #142.
- **#108** skipped: issue body has empty Skills/Query/Expected Output/Assertions sections (template not filled out).
- Empty-rubric warnings on #3, #126, #139, #147, #148, #149 (issue body has an empty `## Rubric Criteria (Assertions)` section) — preserved as-is, since they reflect upstream issue content.

## Notes

- The `gh` CLI is unavailable in this environment, so the sync was run by feeding GitHub MCP issue bodies through `_automation/issue-to-eval/scripts/import_issue_eval.parse_issue_markdown` + `save_to_evals` directly. The MCP returns HTML-encoded text (e.g. `&#39;`, `&#34;`, `&lt;`), so bodies are normalized via `html.unescape` before parsing to keep the on-disk evals byte-identical with prior `gh`-based runs.

## Test plan

- [ ] Re-run `python3 _automation/issue-to-eval/scripts/sync_benchmarks.py` after this PR merges and confirm every parseable issue reports **Skipped** (up to date).
- [ ] `_automation/evals/github-issue-147.json` carries `target_skills: ["admiral-bds"]`, `language: "R"`, and the SYSBP/DIABP/PULSE/WEIGHT/HEIGHT/BMI parameter mapping prompt.
- [ ] `_automation/evals/github-issue-148.json` carries `target_skills: ["admiral-adae"]`, `language: "R"`, and the 30-day TRTEMFL window prompt.
- [ ] `_automation/evals/github-issue-149.json` carries `target_skills: ["admiral-bds"]`, `language: "R"`, and the LB-domain ADLB derivation prompt with spec-driven PARAMCD/PARAM lookup.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FWceWvgytHmrsbfwoPJQEn)_