### PR TITLE
Add clinical trial IPD simulation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A collection of agent skills for pharmaceutical R&D.
 | [clinical-trial-simulation](clinical-trial-simulation/) | Design and simulate clinical trials using the TrialSimulator R package and produce a QC-ready build-order-spine report. Design-agnostic: composes from independent building blocks (endpoints, arms, milestones, regimens) rather than following a fixed catalog of design templates. |
 | [admiral/admiral-adsl](admiral/admiral-adsl/) | Derive ADaM Subject-Level Analysis Datasets (ADSL) from SDTM domains using the {admiral} R package. Encodes the workflow, function selection logic, and CDISC conventions for QC-ready, submission-traceable R code. |
 | [admiral/admiral-bds](admiral/admiral-bds/) | Derive ADaM BDS findings datasets (ADVS, ADLB) from SDTM VS/LB domains. Covers parameter assignment, baseline flagging, change from baseline, visit windowing, and ADLB normal range derivations. |
+| [clinical-trial-ipd-sim](clinical-trial-ipd-sim/) | Generate synthetic IPD, source CRFs, and exports for registered clinical trials using an R/pharmaverse g-formula causal-DAG workflow calibrated to posted protocol and results. |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of agent skills for pharmaceutical R&D.
 | [clinical-trial-simulation](clinical-trial-simulation/) | Design and simulate clinical trials using the TrialSimulator R package and produce a QC-ready build-order-spine report. Design-agnostic: composes from independent building blocks (endpoints, arms, milestones, regimens) rather than following a fixed catalog of design templates. |
 | [admiral/admiral-adsl](admiral/admiral-adsl/) | Derive ADaM Subject-Level Analysis Datasets (ADSL) from SDTM domains using the {admiral} R package. Encodes the workflow, function selection logic, and CDISC conventions for QC-ready, submission-traceable R code. |
 | [admiral/admiral-bds](admiral/admiral-bds/) | Derive ADaM BDS findings datasets (ADVS, ADLB) from SDTM VS/LB domains. Covers parameter assignment, baseline flagging, change from baseline, visit windowing, and ADLB normal range derivations. |
-| [clinical-trial-ipd-sim](clinical-trial-ipd-sim/) | Generate synthetic IPD, source CRFs, and exports for registered clinical trials using an R/pharmaverse g-formula causal-DAG workflow calibrated to posted protocol and results. |
+| [clinical-trial-ipd-sim](clinical-trial-ipd-sim/) | Generate synthetic IPD, source CRFs, SDTM, ADaM, and exports for registered clinical trials using an R/pharmaverse g-formula causal-DAG workflow calibrated to posted protocol and results. |
 
 ## Usage
 

--- a/clinical-trial-ipd-sim/LICENSE
+++ b/clinical-trial-ipd-sim/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joshua Chen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clinical-trial-ipd-sim/LICENSE
+++ b/clinical-trial-ipd-sim/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Joshua Chen
+Copyright (c) 2026 Keiji AI, Erick Scott, Joshua Chen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clinical-trial-ipd-sim/README.md
+++ b/clinical-trial-ipd-sim/README.md
@@ -1,0 +1,169 @@
+# clinical-trial-ipd-sim
+
+Claude Code skill for generating individual-patient-data (IPD) CRFs for a
+registered clinical trial using an R/pharmaverse g-formula causal-DAG
+simulator. Given an NCT ID with posted protocol and results, the skill
+produces synthetic source CRFs, SDTM-style domains, ADaM analysis datasets,
+TLGs, and export files whose marginal statistics match the published trial
+AND whose joint distribution follows an explicit, identifiable causal DAG.
+
+## Why this exists
+
+Trial-summary reconstruction methods (digitized KM curves, marginal AE
+proportions) reproduce headline numbers but lose all within-patient
+structure. Most "synthetic IPD" generators draw outcomes from
+independent parametric distributions conditional on arm — the resulting
+data cannot support causal-inference methodology because:
+
+- AE types are conditionally independent given arm (no shared frailty)
+- Labs and AEs are not mechanistically linked
+- Endpoints (PFS, OS) are sampled directly rather than derived from
+  the longitudinal trajectory
+
+This skill produces simulators where every node has explicit causal
+parents, latent patient frailties induce realistic within-patient
+correlation across the trajectory, and endpoints are deterministic
+functionals of the simulated state.
+
+## When the skill fires
+
+Use this skill when the user provides, or asks you to identify, an NCT ID
+and wants synthetic IPD, source CRFs, a digital-twin cohort, or a simulated
+trial reconstruction. The skill assumes the trial has posted results and an
+available protocol document, either on ClinicalTrials.gov, in a journal
+supplement, or supplied by the user.
+
+## Files in this skill
+
+| File | Purpose |
+|---|---|
+| [`SKILL.md`](SKILL.md) | Main workflow — the six-step pipeline (intake -> CRF derivation -> SCM construction -> parameterization -> forward sim -> calibration). Includes causality invariants. |
+| [`r_implementation.md`](r_implementation.md) | R implementation guide — package layout, pharmaverse package roles, SDTM/ADaM/TLG/export flow, and R validation rules. |
+| [`calibration.md`](calibration.md) | Sub-skill for the iterative calibration loop. Tables of allowed vs. forbidden parameter knobs; gate-based fail-closed algorithm. |
+| [`templates/scm_spec_template.md`](templates/scm_spec_template.md) | Rigorous SCM specification template. Forces per-variable dossiers covering DAG parents, mechanism, functional form, parameter priors with citations, identifiability checks, d-separation implications, and validation gates. |
+| [`templates/crf_schema_template.md`](templates/crf_schema_template.md) | CDISC-aligned CRF schema template — visit grid, per-form dossier, variable list, SoA crosswalk. |
+
+## Pipeline at a glance
+
+```
+NCT ID
+  │
+  ▼
+Step 1 · Intake from ClinicalTrials.gov
+  → trial design, eligibility, endpoints, AE table, protocol PDF
+  ▼
+Step 2 · Parse SoA → CRF schema
+  → form × visit × variable matrix
+  ▼
+Step 3 · Build SCMs from literature + protocol
+  → dag_spec.md per template
+  ▼
+Step 4 · Parameterize from CTGov results + literature
+  → parameter table with citations
+  ▼
+Step 5 · g-formula forward simulation
+  → per-patient: L₀ → A → L₁ → … → Lₜ → Yₜ
+  → emit source CRFs, then SDTM/ADaM via pharmaverse packages
+  ▼
+Step 6 · Calibration loop (causality-preserving)
+  → DAG gates pass before any param update is accepted
+  → adjust scale/intercept/hazard/variance only
+  → halt when marginals within tolerance OR causality regression detected
+  ▼
+Final CRFs + SDTM/ADaM + TLGs + exports + analysis report
+```
+
+## Causality invariants
+
+The skill enforces these constraints throughout, especially during
+calibration. They distinguish a true SCM-based simulator from a
+marginal-effect simulator dressed up with extra forms:
+
+1. **Endpoints are functionals of the trajectory**, never independent
+   draws. `PFS_DAY = min(progression_day, death_day, ADMIN_CENSOR)` where
+   `progression_day` comes from the simulated SLD trajectory hitting
+   RECIST PD criteria.
+2. **AEs derive from their causal parents**: heme AEs are CTCAE grades
+   of simulated lab values; non-lab AEs are sampled from per-visit
+   hazards depending on arm and shared latent frailties.
+3. **Latent frailties are mandatory** for any cluster of correlated AE
+   preferred terms or lab values. Their variances are tunable but
+   cannot be set to zero (that would be a structural change, not
+   calibration).
+4. **No direct A → Y edges** that bypass the modeled mediators. All
+   treatment-effect pathways flow through SLD trajectory, AEs, dose
+   modifications, ECOG, and discontinuation.
+5. **Deterministic CTCAE / RECIST rules are fixed**. Calibration tunes
+   the *inputs* to those rules (lab dynamics, SLD trajectory), never
+   the rules themselves.
+
+The full list with worked counter-examples is in [`SKILL.md`](SKILL.md)
+and [`calibration.md`](calibration.md).
+
+## Suggested smoke test — FLAURA2 (NCT04035486)
+
+FLAURA2 is a useful public smoke-test scenario because it has posted
+ClinicalTrials.gov results, a published primary analysis, two treatment arms,
+PFS, response endpoints, chemotherapy-associated lab toxicity, and a rich AE
+profile. Use it to exercise the workflow end to end:
+
+1. Fetch and persist the ClinicalTrials.gov v2 record.
+2. Locate the protocol and schedule of activities.
+3. Build the CRF schema and `dag_spec.md`.
+4. Parameterize the SCM from CTGov results and cited literature.
+5. Implement the simulator in R, following [`r_implementation.md`](r_implementation.md).
+6. Calibrate to published PFS and AE targets while keeping all DAG gates
+   passing.
+
+The implementation should use pharmaverse packages for standards and outputs:
+
+- `sdtm.oak` for SDTM-oriented domain construction.
+- `admiral` for ADaM derivations.
+- `haven` for SAS data interoperability where needed.
+- `tidytlg` for TLGs.
+- `xportr` for XPT metadata/export.
+- `datasetjson` for Dataset-JSON export.
+
+## Required tools
+
+- R 4.3+ with `renv`
+- R packages: `dplyr`, `tidyr`, `purrr`, `readr`, `tibble`, `lubridate`,
+  `stringr`, `survival`, `flexsurv`, `broom`, `jsonlite`, `testthat`
+- Pharmaverse/CDISC packages: `sdtm.oak`, `admiral`, `haven`, `tidytlg`,
+  `xportr`, `datasetjson`
+- `WebFetch` / `WebSearch` for ClinicalTrials.gov API and literature
+- File-system access for CSV, XPT, Dataset-JSON, and TLG emission
+
+## Limitations
+
+- The skill does not address summary-level reconstruction (KM digitization,
+  pure marginal sampling) — for those use cases, simpler IPD-from-summary
+  methods are appropriate.
+- ClinicalTrials.gov coverage is uneven; trials without posted protocols
+  or with sparse AE tables will require user-supplied supplementary data.
+- The calibration loop is a local search over parameter values; if the
+  published marginals are inconsistent with the SCM structure (e.g.,
+  effect sizes that imply unmodeled mediators), the loop will plateau
+  and report a structural review recommendation rather than continue
+  fitting.
+
+## Extending
+
+To adapt to a new disease area:
+
+1. Replace the FLAURA2 AE catalog and frailty cluster definitions
+   in `R/longitudinal.R` with the new disease's typical AE
+   profile.
+2. Replace the SLD-based RECIST tumor model with the disease's
+   appropriate response criteria (e.g., IMWG for myeloma, Cheson for
+   lymphoma).
+3. Update `dag_spec.md` to reflect biomarker stratifiers relevant to
+   the new indication.
+4. Re-elicit parameter priors from the new indication's literature.
+
+The g-formula structural skeleton (`baseline → arm → longitudinal →
+endpoints` with latent frailties shared across the trajectory) is
+disease-agnostic and should be preserved.
+
+## In progress
+1. ODM integration for structured CRF output

--- a/clinical-trial-ipd-sim/README.md
+++ b/clinical-trial-ipd-sim/README.md
@@ -167,3 +167,4 @@ disease-agnostic and should be preserved.
 
 ## In progress
 1. ODM integration for structured CRF output
+2. Paperclip search integration for literature-based evidence

--- a/clinical-trial-ipd-sim/SKILL.md
+++ b/clinical-trial-ipd-sim/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: clinical-trial-ipd-sim
+description: End-to-end R/pharmaverse workflow to simulate individual patient data (IPD) for a registered clinical trial using a g-formula causal-DAG simulator. Given an NCT ID with posted protocol + results, derives SDTM-style CRFs, builds evidence-based structural causal models, parameterizes them from ClinicalTrials.gov / literature priors, runs forward simulation in R, creates SDTM/ADaM outputs with pharmaverse packages, and iteratively calibrates marginal statistics to the published results without breaking causal identifiability.
+metadata:
+  when-to-use: User provides an NCT ID and asks for synthetic IPD / CRF simulation, trial reconstruction, or any phrase like "simulate trial X", "create CRFs for NCT…", "generate digital-twin patients for…".
+---
+
+# Clinical Trial IPD Causal-DAG Simulator
+
+End-to-end R workflow for generating individual-patient-level CRF data for a
+registered clinical trial. The output is a set of CSV CRFs whose marginal
+statistics match the published trial results AND whose joint distribution
+follows an explicit causal DAG, so the data are usable for downstream
+causal-inference methodology.
+
+The implementation target is R-first and pharmaverse-compatible. The Python
+FLAURA2 build used during development remains a worked example of the causal
+logic, but new work should create an R package-style project unless the user
+explicitly asks for Python. See [r_implementation.md](r_implementation.md)
+for the R module layout and package roles.
+
+This skill generalizes the FLAURA2 causal-DAG workflow into an
+R/pharmaverse implementation target.
+
+## When to use
+
+The user provides an NCT ID **and** the trial has both a posted protocol and
+posted results. Examples:
+
+- "Simulate IPD for NCT04035486" → use this skill
+- "Generate CRFs for the AEGEAN trial" → look up NCT, then use this skill
+- "Create a digital-twin cohort for trial X" → use this skill
+- "I need synthetic patients matching the published KM curves of …" → use this skill
+
+Do **not** use when the user only wants summary-level reconstruction (Cox HR,
+KM medians, AE proportions). For that, reach for tabular reconstruction
+methods (e.g., reconstructed IPD from KM digitization).
+
+## Required environment
+
+- R 4.3+ with `renv` for dependency locking.
+- Core simulation/analysis: `dplyr`, `tidyr`, `purrr`, `readr`, `tibble`,
+  `lubridate`, `stringr`, `rlang`, `survival`, `flexsurv`, `broom`, `jsonlite`.
+- Pharmaverse/CDISC stack:
+  - `sdtm.oak` for SDTM-oriented CRF/domain construction from generated source records.
+  - `admiral` for ADaM derivations such as ADSL, ADAE, ADLB, ADTTE.
+  - `haven` for reading/writing SAS transport-adjacent inputs and SAS datasets when needed.
+  - `tidytlg` for TLG generation from ADaM outputs.
+  - `xportr` for XPT metadata handling and transport export.
+  - `datasetjson` for Dataset-JSON export when requested.
+- Network access for the ClinicalTrials.gov API (`https://clinicaltrials.gov/api/v2/studies/{nct}`)
+- Citation-capable literature and standards lookup for causal-parent
+  evidence, natural-history rates, priors, CTCAE, and RECIST references.
+  Record stable source identifiers for all non-CTGov evidence; do not rely
+  on model memory for cited claims.
+- `WebFetch` or equivalent only for fetching specific known URLs
+  (the ClinicalTrials.gov API, a protocol PDF, a publication supplement)
+
+## Workflow — six steps
+
+### Step 1 · Intake from ClinicalTrials.gov
+
+1. Fetch the trial JSON record:
+   `https://clinicaltrials.gov/api/v2/studies/{NCT_ID}?format=json`
+2. Extract:
+   - **Design**: arms, randomization ratio, stratification factors, primary/secondary endpoints
+   - **Eligibility**: inclusion/exclusion criteria → baseline population priors
+   - **Outcomes table**: per-arm event counts, medians, hazard ratios with 95% CIs
+   - **Adverse events table**: per-arm SOC/PT counts at any-grade, Gr ≥3, SAE
+   - **Protocol document URL** (under `ProtocolSection.IPDSharingStatementModule` or `LargeDocumentsModule`)
+3. Locate the **schedule of activities (SoA)** in the protocol PDF/HTML.
+   If the SoA cannot be parsed automatically, ask the user to point at the
+   relevant pages, or scaffold a default visit grid based on the dosing schedule.
+   If ClinicalTrials.gov does not provide a protocol, search for the protocol
+   or supplementary appendix in the New England Journal of Medicine (NEJM).
+   If neither source has a protocol, ask the user to provide one and do not
+   proceed until it is available.
+4. Persist the intake to `intake/{NCT_ID}.json` so later steps don't re-fetch.
+
+**Output of step 1**: structured trial summary with design, endpoint targets,
+AE targets, and SoA visit grid.
+
+### Step 2 · CRF derivation from the protocol
+
+Read the protocol's SoA and generate a CDISC-style CRF schema:
+
+| Form | Visits collected | Variables | Source |
+|---|---|---|---|
+| Demographics | Screening | AGE, SEX, RACE, COUNTRY, ARM | Protocol §X |
+| Cancer/Disease History | Screening | Diagnosis, stage, biomarker stratifiers | Protocol §X |
+| Lab Hematology | Cycle days, maintenance | WBC, ANC, HGB, PLT, LYMPH | SoA |
+| Tumor Assessment | q6w (or per protocol) | SLD, response, new lesions | RECIST 1.1 |
+| Adverse Events | Each visit | AE term, grade, severity, action, relatedness | CTCAE |
+| Disposition | EOT | Reason for discontinuation | SoA |
+| Survival Follow-Up | Survival period | PFS time/event, OS time/event | Endpoint definitions |
+| … | … | … | … |
+
+Use [templates/crf_schema_template.md](templates/crf_schema_template.md) as
+the starting structure. Defer to the protocol's SoA when present; fall back
+to FLAURA2-style defaults when the user accepts.
+
+**Output of step 2**: a `crf_schema.md` listing each form, its column set,
+and the visit grid at which each form is collected. For R builds, also
+create `metadata/sdtm_spec.csv` and `metadata/adam_spec.csv` stubs that can
+drive `sdtm.oak`, `admiral`, `xportr`, and `datasetjson`.
+
+### Step 3 · Build evidence-based structural causal models
+
+For every variable in the CRF schema, specify its DAG parents and the
+functional form of its structural equation.
+
+**Process:**
+1. Categorize variables into the four DAG layers:
+   - **L₀ — Baseline** (eligibility-shaped covariates and patient frailties)
+   - **A — Treatment** (arm assignment, randomization)
+   - **Lₜ — Time-varying state** (labs, tumor, AEs, dose modifications, ECOG)
+   - **Yₜ — Endpoints** (PFS, OS, response — derived from trajectory)
+2. For each variable, gather cited evidence on its causal parents. Never
+   assert a causal edge from memory. Look for:
+   - Trial protocol (stratification factors → baseline parent edges)
+   - Disease-area review papers (e.g., for NSCLC: TP53 → response, EGFR-type → PFS)
+   - Drug mechanism papers (e.g., chemo → myelosuppression timing/depth)
+   - CTCAE / RECIST documents (deterministic rules from labs/SLD → AE/response)
+   - Prior published simulators or natural-history models
+3. Document the DAG using [templates/scm_spec_template.md](templates/scm_spec_template.md).
+   Each row: `variable | parents | functional form | evidence source`.
+4. Introduce **latent frailty random effects** for any cluster of related
+   AE preferred terms or correlated lab values that share a biological
+   pathway. Examples:
+   - `f_heme` shared by ANC/HGB/PLT (myelosuppression susceptibility)
+   - `f_GI` shared by nausea/vomiting/diarrhea/stomatitis (chemo emesis)
+   - `f_ILD` for the rare-but-irreversible class effect of EGFR-TKIs
+   - `f_dropout` for unobserved patient-level dropout propensity
+   These frailties are the mechanism that makes the simulated AEs
+   correlated within patient — without them, AE types are independent
+   draws conditional on arm, which is the bug we fixed in the FLAURA2
+   v6 simulator.
+
+**Output of step 3**: `dag_spec.md` with one row per variable, parents,
+structural equation, and source.
+
+### Step 4 · Parameterize the SCMs
+
+For each structural equation, set its parameters from a hierarchy of priors:
+
+1. **ClinicalTrials.gov results JSON** (highest priority; closest to ground truth)
+   - Per-arm AE preferred-term counts → mono and combo per-visit hazards
+   - Per-arm SAE rates → severity multipliers
+   - Per-arm KM medians, HR with 95% CI → time-to-resistance scale + treatment effect
+   - Discontinuation rates by reason → discontinuation-hazard intercepts
+2. **Foundation-model knowledge** (sanity-check defaults)
+   - CTCAE thresholds for lab grading (deterministic, never tuned)
+   - RECIST 1.1 rules for response classification (deterministic)
+   - Standard drug mechanism timing (e.g., pemetrexed nadir at day 8–10)
+3. **Literature priors** (filling gaps) — gather these from cited
+   publications, protocol supplements, or standards documents; never from
+   uncited memory:
+   - natural-history rates, incidence baselines
+   - disease-area review articles
+   - keep each record's `source_id` alongside the parameter value
+
+**Implementation pattern (R version)**:
+
+```r
+# log-scale parameterization makes treatment effects multiplicative
+log_scale <- log(BASE_DAYS_TO_EVENT) +
+  LOG_HR_FROM_CTGOV * as.numeric(arm == "combo") +
+  STRATIFIER_LOG_EFFECT * stratifier +
+  FRAILTY_LOADING * latent_frailty
+```
+
+**Output of step 4**: a parameter table where each row maps parameter name
+→ value → derivation source (CTGov field path, or PMID, or sanity default).
+
+### Step 5 · G-formula forward simulation
+
+Implement the simulator in R with strict topological propagation:
+
+```r
+For each patient:
+    1. Sample L₀ (baseline + latent frailties) from priors
+    2. Sample A (treatment arm) from randomization
+    3. For each visit t in chronological order:
+        a. Update drug-exposure indicators from prior dose state
+        b. Sample Lₜ from f(Lₜ₋₁, A, drug_exposure, frailties)   # labs, SLD
+        c. Derive AEs from Lₜ where deterministic (CTCAE on labs);
+           sample non-deterministic AEs from frailty + arm hazard
+        d. Apply dose-modification rules from AE thresholds
+        e. Update ECOG and discontinuation hazards
+    4. Derive Yₜ = endpoints from trajectory
+        - PFS_DAY = first(progression_day, death_day, admin_censor)
+        - PFS_EVENT = 1 iff event observed before censor
+    5. Project trajectory → CRF rows (pure projection, no fresh sampling)
+```
+
+R module layout:
+- `R/dag_state.R` — patient state as tibbles/lists, frailty draws, visit grid.
+- `R/baseline.R` — L₀ generation.
+- `R/longitudinal.R` — Lₜ propagation.
+- `R/outcomes.R` — Yₜ derivation from trajectory.
+- `R/emit_source.R` — pure trajectory projection to source-style CRF records.
+- `R/sdtm.R` — SDTM domain construction, using `sdtm.oak` patterns where possible.
+- `R/adam.R` — ADaM derivations with `admiral`.
+- `R/tlg.R` — analysis tables/listings/graphs with `tidytlg`.
+- `R/export.R` — CSV, XPT via `xportr`, Dataset-JSON via `datasetjson`.
+- `R/run.R` — orchestrator.
+
+Read [r_implementation.md](r_implementation.md) before writing or editing
+the R implementation.
+
+**Output of step 5**: populated source CRFs, SDTM-style domains, ADaM
+datasets, and requested export formats for the requested N.
+
+### Step 6 · Calibration loop (with causality preservation)
+
+This is the most subtle step. The naïve approach — "the AE rate is too low,
+add a bigger constant to the AE probability" — works to fix marginals but
+**often violates causality** if it bypasses the parent variables. The
+calibration loop must change parameters of structural equations, never
+their structure.
+
+#### Calibration invariants — **DO NOT VIOLATE**
+
+The following are forbidden during calibration regardless of how much
+discrepancy the marginal stats show:
+
+1. ❌ **Do not draw an endpoint independently of its trajectory parents.**
+   Example violation: drawing PFS_TIME from a Weibull conditioned only on
+   arm to "fix" the median PFS. Correct: tighten `time_to_resistance`
+   scale/shape so the SLD trajectory hits PD criteria at the right time.
+2. ❌ **Do not add new direct edges from arm to outcomes** that bypass the
+   intermediate variables (labs, AEs, dose, response). All treatment-effect
+   pathways must flow through the modeled mediators.
+3. ❌ **Do not derive a child node's value from its own descendants**
+   (cycles in the DAG).
+4. ❌ **Do not collapse independence across patient-shared frailties** —
+   e.g., do not set `f_heme = 0` for all patients to "remove" a correlation;
+   instead change the variance of `f_heme` if its effect is too strong.
+5. ❌ **Do not turn a deterministic CTCAE/RECIST rule into a random draw**
+   to inflate AE rates. The grading function is fixed; the lab value
+   distribution is what's tunable.
+
+#### Calibration loop — allowed knobs
+
+For each marginal mismatch, the loop adjusts only structural-equation
+*parameters*, never the *structure*. Allowed adjustments:
+
+| Mismatch direction | Allowed knob |
+|---|---|
+| Median PFS too short / long | Scale and shape of `time_to_resistance` Weibull, post-resistance growth rate `g`, RECIST nadir-detection lag |
+| HR too weak / strong | Treatment-arm coefficient on `time_to_resistance` (the only direct A-edge) |
+| AE rate too high / low | Per-visit hazard `base_haz`, frailty variance, reporting probability `p_report` |
+| Severe-AE share too high / low | `p_severe` parameter of non-lab AE generator; CTCAE thresholds untouched |
+| Lab toxicity too deep / shallow | Drug-induced drag in lab AR(1) equations; AR coefficients α to control cascading |
+| Discontinuation rate too high / low | Intercept and AE-burden coefficient in discontinuation hazard |
+| AE-AE correlation too low | Increase frailty variance for the relevant cluster (e.g., `f_GI`) |
+| Within-patient lab autocorrelation | AR(1) coefficient α (closer to 1 → more cascade) |
+
+#### Loop algorithm
+
+```
+LOAD targets = ctgov_results(NCT)
+LOAD invariants = ["all DAG edges in dag_spec.md"]
+
+REPEAT up to N_iter (default 8):
+    SIMULATE current_params → CSVs
+    METRICS = compute_marginals(CSVs)
+        - per-arm median PFS + 95% CI
+        - HR (Cox) with 95% CI
+        - Any AE / Gr ≥3 AE / SAE / discontinuation rates per arm
+        - Top 10 PT-level AE rates per arm
+    GATES = run_dag_gates(CSVs)
+        - AE↔lab linkage (deterministic AEs)
+        - Within-patient AE-AE correlation (frailty cluster)
+        - PFS_DAY = trajectory progression (correlation = 1.0)
+        - Stratifier → endpoint effects in expected direction
+
+    ASSERT GATES all pass            # NEVER break causality
+    IF MAX_DISCREPANCY(METRICS, targets) < TOL: BREAK
+
+    PROPOSE param updates that move METRICS toward targets, restricted
+    to the "allowed knobs" table. Prefer single-parameter changes with
+    clear marginal effect; avoid coupled changes that could mask DAG bugs.
+
+    APPLY updates → params_next
+    LOG params_next, METRICS, gate results
+```
+
+The loop **fails closed** — if any DAG gate fails after a parameter update,
+the update is reverted and the loop reports a structural problem rather
+than continuing to chase marginals. Causal identification is paramount.
+
+**Output of step 6**: final calibrated CSVs, parameter audit trail, gate
+results, and a side-by-side table comparing simulated vs. published
+metrics.
+
+## Concrete deliverables
+
+When this skill completes, the working directory contains:
+
+- `intake/{NCT}.json` — raw and parsed CTGov record
+- `crf_schema.md` — list of forms × visits × variables
+- `dag_spec.md` — variable / parents / structural equation / evidence
+- `params/` — per-iteration parameter snapshots (audit trail)
+- `R/` — R modules implementing the simulator and SDTM/ADaM/export pipeline
+- `metadata/` — SDTM/ADaM/export metadata specs for `sdtm.oak`, `admiral`,
+  `xportr`, and `datasetjson`
+- `renv.lock` — reproducible R dependency lockfile
+- `<output>/source/*.csv` — source-style generated CRFs
+- `<output>/sdtm/*.csv` and, when requested, `.xpt` / Dataset-JSON exports
+- `<output>/adam/*.csv` and, when requested, `.xpt` / Dataset-JSON exports
+- `<output>/analysis/` — KM curves, primary endpoint analysis, AE tables, calibration report
+
+## Worked example
+
+The FLAURA2 build (NCT04035486) used during development demonstrates the
+causal model and calibration targets. Treat it as a reference to port into R:
+
+- Intake JSON fields used: `Outcomes`, `AdverseEvents`, `EligibilityCriteria`, `ArmsInterventions`
+- CRF schema: 26 forms across screening / treatment / follow-up
+- DAG: represented in the generated `dag_spec.md` format, with one row per
+  node documenting parents, structural equation, and evidence source
+- Parameters: calibrated to median PFS combo 23.5 mo (pub 25.5), mono 19.3 mo (pub 16.7), HR 0.64 (pub 0.62)
+- Gates passed: AE↔lab linkage (mean ANC at Neutropenia AE = 0.52 vs 4.29 without), GI AE within-patient r ≈ 0.28, PFS↔trajectory r = 1.000
+
+Refer to it as a causal template; do not copy code blindly. New
+implementation work should port the same structure into `R/` and should use
+pharmaverse packages for standards, ADaM derivations, TLGs, and exports.
+Every trial has its own SoA, biomarker stratifiers, and AE profile.
+
+## Common pitfalls
+
+1. **Treating the calibration loop as parameter optimization without DAG
+   constraints.** It must be optimization *subject to* the DAG gates.
+2. **Letting the visit grid extend past the data cutoff.** Set
+   `ADMIN_CENSOR_DAY` from CTGov's data-cutoff date so PFS censoring
+   matches the published analysis.
+3. **Using global RNG state in ad hoc R code and expecting reproducibility
+   across calibration iterations.** Use one controlled seed and consume RNG
+   in a fixed order; otherwise minor parameter changes will appear to cause
+   large output changes simply from RNG-state shifts.
+4. **Independent-draw shortcut for non-lab AEs.** Without a shared
+   frailty, every AE type is conditionally independent given arm — the
+   bug fixed in v6. Always introduce a frailty per AE cluster.
+5. **Drawing endpoints directly.** PFS_TIME must be derived from the
+   trajectory, not sampled from a parametric distribution conditioned
+   on arm. The original FLAURA2 v6 sim violated this; the current
+   causal reference build does not.
+
+## Companion skills / hooks
+
+- `crf-calibration-loop` (sub-skill at [calibration.md](calibration.md)) —
+  the iterative loop with causality-preserving parameter updates,
+  invocable independently when the user wants to tune an existing run.
+- Verification gate functions live alongside the simulator code as
+  `verify_dag_*.R`; they should be runnable as a pre-commit-style hook
+  before any CSVs are released.

--- a/clinical-trial-ipd-sim/calibration.md
+++ b/clinical-trial-ipd-sim/calibration.md
@@ -1,0 +1,218 @@
+# Calibration Sub-Skill — Causality-Preserving Marginal Tuning
+
+This document describes the iterative calibration loop invoked from the
+main `clinical-trial-ipd-sim` skill. It can also be run standalone when
+the user has an existing simulator and wants to tune marginal stats
+toward a fresh CTGov target.
+
+## Purpose
+
+Reduce the discrepancy between simulated marginal statistics and the
+empirical results (ClinicalTrials.gov + published trial paper) **without
+breaking the causal DAG**.
+
+## Inputs
+
+- `R/` — R modules implementing the g-formula simulator
+- `dag_spec.md` — formal DAG specification (variables, parents, equations)
+- `targets.json` — the empirical results to calibrate against:
+  ```json
+  {
+    "median_pfs_months": {"combo": 25.5, "mono": 16.7},
+    "hr": {"point": 0.62, "ci_low": 0.49, "ci_high": 0.79},
+    "ae_any_pct": {"combo": 100, "mono": 97},
+    "ae_gr3plus_pct": {"combo": 64, "mono": 27},
+    "ae_sae_pct": {"combo": 38, "mono": 19},
+    "ae_disc_pct": {"combo": 47, "mono": 6},
+    "top_ae_combo": {"NEUTROPENIA": 31, "ANEMIA": 23, ...}
+  }
+  ```
+- `tolerance.json` — per-metric tolerance band (default ±20% relative or 1
+  CI-width absolute, whichever is tighter)
+
+## DAG gates (must pass at every iteration)
+
+Before a parameter update can be accepted, the simulator must satisfy:
+
+| Gate | Test | Pass criterion |
+|---|---|---|
+| AE-lab linkage | mean ANC at visits with Neutropenia AE | < 1.5 ×10⁹/L |
+| AE-lab linkage | mean HGB at visits with Anemia AE | < 11.0 g/dL |
+| AE-AE correlation | within-patient r among GI AEs (combo) | > 0.20 |
+| AE-AE correlation | within-patient r among heme AEs (combo) | > 0 (signed) |
+| PFS↔trajectory | corr(PFS_DAYS, longitudinal progression day) | > 0.95 |
+| Stratifier sign | TP53 mutant vs WT median PFS | mutant < WT |
+| Stratifier sign | EGFR Ex19del vs L858R median PFS | Ex19del ≥ L858R (per literature) |
+| Topology | no cycles in DAG; every variable has only its declared parents | static check on `dag_spec.md` |
+
+Gates are coded in `R/verify_dag_gates.R` or
+`tests/testthat/test-dag-gates.R` and run as boolean tests. If any gate
+fails after a proposed update, **revert the update and log a causality
+regression**.
+
+## Algorithm
+
+```r
+calibrate <- function(params, targets, tol, max_iter = 8) {
+  history <- list()
+
+  for (it in seq_len(max_iter)) {
+    outputs <- run_simulation(params)
+    metrics <- compute_metrics(outputs)
+    gates <- verify_dag_gates(outputs)
+
+    history[[it]] <- list(
+      iter = it,
+      params = params,
+      metrics = metrics,
+      gates = gates
+    )
+
+    stopifnot(all(unlist(gates)))
+
+    if (max_relative_error(metrics, targets) < tol) {
+      return(list(params = params, history = history))
+    }
+
+    proposed <- propose_update(params, metrics, targets)
+    trial_outputs <- run_simulation(proposed)
+
+    if (all(unlist(verify_dag_gates(trial_outputs)))) {
+      params <- proposed
+    } else {
+      history[[it]]$rejected <- proposed
+      params <- back_off(params, proposed)
+    }
+  }
+
+  list(params = params, history = history)
+}
+```
+
+## Allowed parameter knobs
+
+These are the only parameters the loop may modify. Anything else
+constitutes a structural change and must be reviewed by the user.
+
+### Time-to-event scale knobs
+
+| Knob | Affects | Increase to … |
+|---|---|---|
+| `BASE_TIME_TO_RESISTANCE_DAYS` | Mono-arm PFS scale | Lengthen mono median PFS |
+| `LOG_HR_ARM` | Combo-arm multiplicative scale | Strengthen treatment effect (HR ↓) |
+| `WEIBULL_SHAPE` | Spread of time-to-resistance | Tighter shape → narrower CI |
+| `POST_RESIST_GROWTH_RATE` | SLD regrowth speed | Shorter PFS-after-resistance lag |
+
+### AE rate knobs
+
+| Knob | Affects | Increase to … |
+|---|---|---|
+| `BASE_HAZ_<AE>` | Per-visit hazard for that AE while on treatment | Inflate any-grade rate of that AE |
+| `COMBO_RR_<AE>` | Combo-arm relative risk | Widen mono/combo gap for that AE |
+| `P_SEVERE_<AE>` | P(grade ≥3 ∣ event) | Inflate Gr ≥3 share without changing any-grade |
+| `P_REPORT_LOWGRADE` | Reporting probability for lab Gr 1–2 events | Inflate any-grade lab AE rate |
+| `OFF_TREATMENT_HAZARD_DOWNSCALE` | Multiplier for AE hazard after EOT | Decrease post-EOT AE inflation |
+
+### Lab dynamics knobs
+
+| Knob | Affects | Increase to … |
+|---|---|---|
+| `AR_COEF_<LAB>` (α) | Within-patient autocorrelation | Stronger cascade of low values |
+| `CHEMO_DRAG_<LAB>` | Mean nadir depth during chemo | Deeper nadirs |
+| `CHEMO_DRAG_FRAILTY_<LAB>` | Frailty multiplier on nadir | Wider patient-level variation |
+| `LAB_NOISE_<LAB>` | σ of per-visit residual | Bigger random shocks |
+
+### Frailty knobs
+
+| Knob | Affects | Increase to … |
+|---|---|---|
+| `SIGMA_F_HEME` | Heme cluster correlation strength | Stronger ANC/HGB/PLT shared variation |
+| `SIGMA_F_GI` | GI cluster correlation | Stronger nausea/vomiting/diarrhea correlation |
+| `SIGMA_F_<...>` | Other clusters | Same |
+
+### Discontinuation knobs
+
+| Knob | Affects | Increase to … |
+|---|---|---|
+| `DISC_INTERCEPT` | Baseline discontinuation hazard | More dropout overall |
+| `DISC_AE_BURDEN_COEF` | AE-driven discontinuation | More AE-related dropout |
+| `DISC_FRAILTY_COEF` | Patient-level dropout heterogeneity | More heterogeneous dropout |
+
+## Forbidden knobs (would break causality)
+
+- ❌ Direct PFS time draw conditional on arm (bypasses trajectory)
+- ❌ Hard-coding a specific patient subset to have a particular outcome
+- ❌ Adding a new edge from a descendant back to an ancestor
+- ❌ Replacing a deterministic CTCAE/RECIST rule with a stochastic mapping
+- ❌ Conditioning a baseline node on a post-baseline variable
+- ❌ Setting any `SIGMA_F_*` to exactly 0 (use a small positive value
+  if you need to dampen, but full removal eliminates patient-level
+  correlation entirely)
+
+## Update proposal heuristics
+
+Prefer in this order:
+
+1. **Single-knob, large-effect changes first.** If median PFS is off by
+   30%, change `BASE_TIME_TO_RESISTANCE_DAYS` alone. Don't simultaneously
+   tweak the post-resistance growth rate — you'll lose attribution.
+2. **Match log-scale targets log-linearly.** For HR: if current HR is
+   `h_now` and target is `h*`, propose `LOG_HR_ARM_new = LOG_HR_ARM_old + ln(h*/h_now)`.
+3. **AE rates: tune `base_haz` first, `p_severe` second.** Any-grade rate
+   tells you about hazard; severe-grade share tells you about `p_severe`.
+4. **Move at most 2 knobs per iteration.** More than 2 simultaneous
+   changes makes diagnosis impossible if a gate breaks.
+5. **Cap relative parameter changes at ×1.5 per iteration.** Prevents
+   oscillation.
+
+## Termination criteria
+
+- All marginal metrics within tolerance: SUCCESS
+- All gates passing but discrepancies plateau across 3 iterations:
+  STALLED — report which metrics could not be hit and which knobs were
+  exhausted; suggest a structural review of the DAG (e.g., maybe the
+  trial's discontinuation pattern requires a non-modeled mediator).
+- Any gate broken: HALT — report which gate, which knob caused it,
+  and roll back to the last valid parameter set.
+
+## Example log
+
+```
+iter 0: PFS_combo=18.0 (target 24.0), HR=0.88 (target 0.65)
+        gates OK. Proposed: bump LOG_HR_ARM by +0.30, BASE_TTR by ×1.25
+iter 1: PFS_combo=22.8, HR=0.67
+        gates OK. Within tolerance. STOP.
+```
+
+## Output
+
+After the loop terminates, write a calibration report:
+
+```markdown
+# Calibration report — NCT{NCTID}
+
+## Final marginals vs targets
+| Metric | Target | Final | Δ% |
+|---|---|---|---|
+| Median PFS, combo | 24.0 mo | 22.8 mo | -5.0% |
+| HR | 0.65 | 0.67 | +3.1% |
+| ... | ... | ... | ... |
+
+## DAG gates (final)
+- AE↔lab linkage: PASS (ANC@Neut = 0.52)
+- ...
+
+## Parameter trajectory
+[per-iteration param snapshots]
+
+## Knobs exhausted (if STALLED)
+- ...
+```
+
+This report is the artifact the user reviews before accepting the simulated
+CRFs as final.
+
+For R builds, also emit machine-readable calibration history under
+`params/` as JSON/CSV and include SDTM/ADaM/TLG/export validation status in
+the final report. Export validation should use the same final accepted
+parameter set and must not introduce fresh randomness.

--- a/clinical-trial-ipd-sim/r_implementation.md
+++ b/clinical-trial-ipd-sim/r_implementation.md
@@ -1,0 +1,213 @@
+# R Implementation Guide
+
+Use this guide whenever the IPD simulator is implemented or ported in R.
+The causal engine remains a g-formula SCM; the pharmaverse stack is used
+to standardize, derive, report, and export the simulated records.
+
+## Package Roles
+
+| Package | Use in this skill | Do not use for |
+|---|---|---|
+| `sdtm.oak` | Build SDTM-oriented domains from generated source records and metadata-driven mappings. | Causal simulation logic. |
+| `admiral` | Derive ADaM datasets such as ADSL, ADAE, ADLB, ADTTE from SDTM/source domains. | Raw longitudinal state generation. |
+| `haven` | Read user-supplied SAS datasets or write SAS-compatible intermediate files when needed. | Primary XPT regulatory export when `xportr` is available. |
+| `tidytlg` | Generate tables, listings, and graphs from ADaM outputs. | Data derivation or causal calibration. |
+| `xportr` | Apply metadata and write XPT transport files for SDTM/ADaM deliverables. | Simulation or analysis modeling. |
+| `datasetjson` | Emit Dataset-JSON deliverables from SDTM/ADaM datasets when requested. | CSV-only exploratory output. |
+
+Official references:
+
+- `sdtm.oak`: https://pharmaverse.github.io/sdtm.oak/
+- `admiral`: https://pharmaverse.github.io/admiral/
+- `haven`: https://haven.tidyverse.org/
+- `tidytlg`: https://pharmaverse.github.io/tidytlg/
+- `xportr`: https://pharmaverse.github.io/xportr/
+- `datasetjson`: https://cran.r-universe.dev/datasetjson/doc/datasetjson.html
+
+Core non-pharmaverse packages:
+
+- `dplyr`, `tidyr`, `purrr`, `tibble`, `readr`, `stringr`, `lubridate`,
+  `rlang` for data manipulation and orchestration.
+- `survival`, `flexsurv`, `broom` for KM, Cox, and parametric survival
+  calibration summaries.
+- `jsonlite` for ClinicalTrials.gov intake and parameter snapshots.
+- `testthat` for DAG gates and regression tests.
+
+## Project Layout
+
+Create an R package-style repository unless the user provides a different
+structure.
+
+```text
+.
+├── DESCRIPTION
+├── renv.lock
+├── R/
+│   ├── dag_state.R
+│   ├── baseline.R
+│   ├── longitudinal.R
+│   ├── outcomes.R
+│   ├── emit_source.R
+│   ├── sdtm.R
+│   ├── adam.R
+│   ├── tlg.R
+│   ├── export.R
+│   ├── calibrate.R
+│   └── run.R
+├── data-raw/
+│   └── intake/
+├── metadata/
+│   ├── crf_schema.csv
+│   ├── sdtm_spec.csv
+│   ├── adam_spec.csv
+│   ├── define_spec.csv
+│   └── export_spec.csv
+├── tests/testthat/
+│   ├── test-dag-gates.R
+│   ├── test-endpoints.R
+│   ├── test-sdtm.R
+│   └── test-adam.R
+└── output/
+    ├── source/
+    ├── sdtm/
+    ├── adam/
+    ├── tlg/
+    └── analysis/
+```
+
+## Data Flow
+
+Keep the causal simulator separate from standards derivation:
+
+```text
+ClinicalTrials.gov + protocol + literature
+  -> intake JSON and parameter tables
+  -> source simulation tibbles
+  -> SDTM domains with sdtm.oak-style metadata mappings
+  -> ADaM datasets with admiral
+  -> TLGs with tidytlg
+  -> CSV/XPT/Dataset-JSON exports with readr/xportr/datasetjson
+```
+
+The source simulator owns all randomness. SDTM, ADaM, TLG, and export
+steps are deterministic projections or derivations from simulated source
+records.
+
+## R Module Contract
+
+`R/dag_state.R`
+
+- Define visit grid, administrative censor day, CTCAE/RECIST constants,
+  and helper constructors.
+- Return tibbles or named lists with stable columns. Avoid S4/R6 unless
+  there is a clear package reason.
+- Store frailties once per subject and pass them through longitudinal
+  generation.
+
+`R/baseline.R`
+
+- `make_baseline(subject_id, params, rng_stream)` samples L0 and treatment.
+- Sample baseline variables in topological order.
+- Treatment is randomized according to protocol ratio and stratification.
+
+`R/longitudinal.R`
+
+- `simulate_trajectory(patient, params, visit_grid)` returns one row per
+  subject-visit with latent and observed state.
+- Update in this order: exposure, labs, tumor/RECIST, AEs, dose actions,
+  ECOG, discontinuation.
+- Lab AEs must derive from lab values through fixed CTCAE rules plus a
+  reporting model.
+- Non-lab AEs use per-visit hazards with arm, exposure, recurrence, and
+  frailty parents.
+
+`R/outcomes.R`
+
+- `derive_endpoints(patient, trajectory, params)` derives PFS/OS from
+  trajectory. Never draw PFS directly from arm.
+- PFS is `min(progression_day, death_day, admin_censor_day)`.
+
+`R/emit_source.R`
+
+- Convert simulated patient and trajectory objects into source CRF-style
+  tibbles.
+- No fresh random draws in this layer. If a field needs stochastic
+  variation, generate it upstream in `baseline.R` or `longitudinal.R`.
+
+`R/sdtm.R`
+
+- Build SDTM-style domains from source records and `metadata/sdtm_spec.csv`.
+- Prefer `sdtm.oak` patterns for metadata-driven mappings where they fit.
+- Preserve traceability columns back to source rows where practical.
+
+`R/adam.R`
+
+- Use `admiral` derivation functions where practical.
+- At minimum, derive:
+  - `ADSL`: subject-level demographics, arm, stratifiers, baseline status.
+  - `ADAE`: AE analysis records, severity flags, treatment-emergent flags.
+  - `ADLB`: lab analysis values, baseline/change, toxicity grades.
+  - `ADTTE`: PFS/OS time-to-event parameters.
+
+`R/tlg.R`
+
+- Use `tidytlg` for AE summaries, PFS/KM tables, disposition summaries,
+  and calibration comparison tables.
+
+`R/export.R`
+
+- Write CSV with `readr`.
+- Use `xportr` for XPT outputs using `metadata/export_spec.csv`.
+- Use `datasetjson` for Dataset-JSON outputs when requested.
+
+`R/calibrate.R`
+
+- Implement the causality-preserving loop from `calibration.md`.
+- Each accepted parameter update must pass DAG gates.
+
+## Metadata Stubs
+
+Create these files early, even if incomplete:
+
+- `metadata/crf_schema.csv`: form, visit, variable, type, required,
+  source, SCM node.
+- `metadata/sdtm_spec.csv`: domain, source dataset, source variable,
+  target variable, derivation, codelist, role.
+- `metadata/adam_spec.csv`: dataset, parameter, source domain, derivation,
+  analysis flag, population flag.
+- `metadata/export_spec.csv`: dataset, variable, label, type, length,
+  controlled terminology, origin.
+
+Keep metadata human-readable and version-controlled. Do not bury
+standards mappings inside procedural R code.
+
+## Validation
+
+Implement `tests/testthat/test-dag-gates.R` with gates equivalent to the
+calibration spec:
+
+- Lab AE linkage: neutropenia records occur when ANC is low; anemia records
+  occur when HGB is low.
+- AE cluster correlation: shared frailties induce positive within-patient
+  correlation for relevant AE clusters.
+- Endpoint linkage: PFS event days match progression/death trajectory
+  records.
+- Stratifier direction: biomarker prognostic effects move endpoints in the
+  expected direction.
+- Standards checks: SDTM/ADaM required variables are present; XPT/Dataset-
+  JSON exports are deterministic from final datasets.
+
+Do not accept a marginal calibration improvement if any DAG gate regresses.
+
+## R Coding Rules
+
+- Use explicit parameters objects (`params` lists/tibbles) instead of
+  hard-coded constants scattered through functions.
+- Keep random number generation in `baseline.R` and `longitudinal.R`.
+- Return tibbles with stable column names; avoid implicit row ordering as
+  a contract.
+- Prefer vectorized tidyverse code for domain derivations, but use clear
+  per-patient loops for longitudinal state propagation when causal order is
+  easier to audit.
+- Every non-trivial causal edge and parameter prior needs a source in
+  `dag_spec.md` or the parameter table.

--- a/clinical-trial-ipd-sim/templates/crf_schema_template.md
+++ b/clinical-trial-ipd-sim/templates/crf_schema_template.md
@@ -1,0 +1,130 @@
+# CRF Schema — {TRIAL_NAME} (NCT{NCTID})
+
+Derived from the protocol's Schedule of Activities (SoA). Each form
+documents its visit grid, variable set with CDISC-aligned naming, source
+in the protocol, and how the form's variables map onto the SCM.
+
+For R builds, this schema is also the source for pharmaverse metadata:
+`metadata/sdtm_spec.csv`, `metadata/adam_spec.csv`, and
+`metadata/export_spec.csv`. Keep derivation rules explicit enough for
+`sdtm.oak`, `admiral`, `xportr`, and `datasetjson` steps to be generated
+without reverse-engineering procedural code.
+
+## Trial-level visit grid
+
+| Visit code | Visit number | Study day | Description | Source |
+|---|---|---|---|---|
+| SCREENING | 1 | -28 to -1 | Screening | Protocol §X |
+| C1D1 | 2 | 1 | Cycle 1 Day 1 | Protocol §X |
+| ... | ... | ... | ... | ... |
+| FU_W{n} | ... | every 6 weeks (q6w) | Follow-up assessment | Protocol §X |
+| EOT | 99 | variable | End of Treatment | Protocol §X |
+| ADMIN_CENSOR | — | from CTGov data cutoff | Administrative censor | CTGov record |
+
+Document any **stratified randomization** factors that shape the visit
+grid (e.g., different scan schedule for CNS-mets subgroup).
+
+## Form inventory
+
+For each form, complete the dossier below.
+
+### Template
+
+```
+### Form: <NAME>
+
+- **Domain (CDISC)**: e.g. DM, AE, LB, EX, EG, VS, RS, DS, SU
+- **Source in protocol**: §X.Y, page Z
+- **Visit grid**: list of visit codes where this form is collected
+- **Trigger conditions** (if not collected at every listed visit):
+  - e.g., Disease Progression form only when RECIST PD observed
+  - e.g., CNS Assessment only when CNS_METS=Y at baseline
+- **Variables** (table below)
+- **SCM mapping**: for each variable, which SCM node generates it; for
+  derived columns (e.g., LBSTRESN), document the projection rule
+- **Edit checks** (data-quality constraints that the simulator must
+  satisfy):
+  - e.g., LBDTC must be within ±3 days of visit window
+  - e.g., AESTDTC ≤ AEENDTC when both present
+- **Missingness model**: which fields are conditionally missing and on
+  what
+- **Mock row**: one realistic example row to anchor the schema
+```
+
+### Per-variable columns
+
+| CDISC name | Type | Allowed values / units | Source SCM node | Derivation | Required? | Notes |
+|---|---|---|---|---|---|---|
+| USUBJID | char | study-site-subject ID | Patient ID | identity | yes | |
+| VISIT | char | visit label | Visit grid | identity | yes | |
+| LBDTC | date ISO 8601 | YYYY-MM-DD | `visit_day → date` | `baseline_date + visit_day - 1` | yes | |
+| LBORRES | numeric | per-test units | SCM lab node | identity | yes | |
+| LBSTRESC | char | normalized | LBORRES | unit conversion | yes | |
+| LBNRIND | char | NORMAL / HIGH / LOW | LBSTRESC + reference range | rule-based | optional | |
+| ... | ... | ... | ... | ... | ... | ... |
+
+---
+
+## Required forms (oncology trial baseline)
+
+Complete dossier for each:
+
+1. **Demographics (DM)** — once at screening; parents to baseline labs and ECOG
+2. **Inclusion/Exclusion (IE)** — declares the eligibility filter; constrains the L₀ support
+3. **Medical History (MH)** — comorbidities; parents to baseline labs and ECOG
+4. **Cancer/Disease History** — disease characterization; parents to baseline tumor and stratifiers
+5. **Biomarker Testing** — stratifier biomarkers (e.g., EGFR, TP53, PD-L1)
+6. **Prior Therapy (PR)** — prior systemic / radiation / surgery exposures
+7. **Physical Exam (PE)** — per protocol's SoA frequency
+8. **Vital Signs (VS)** — per SoA
+9. **WHO/ECOG Performance Status** — at every clinical visit
+10. **Lab Hematology (LB)** — frequency from SoA; emits ANC/HGB/PLT/WBC/LYMPH per visit
+11. **Lab Chemistry (LB)** — ALT/AST/CREAT/TBIL/ALB/electrolytes
+12. **Lab Urinalysis (LB)** — if in SoA
+13. **ECG (EG)** — per SoA; emits QTcF
+14. **Patient-Reported Outcomes** — QLQ-C30 and disease-specific module; documents the time grid
+15. **Drug Administration (EX)** — one per investigational drug
+16. **Concomitant Medications (CM)** — supportive care; causally downstream of AEs
+17. **Dose Modifications** — descendant of AEs, never a parent
+18. **Adverse Events (AE)** — per CTCAE; one row per AE event with grade, severity, action
+19. **Serious AE (SAE)** — subset of AEs meeting seriousness criteria
+20. **Tumor Assessment (RS)** — RECIST 1.1 schedule (typically q6w → q12w)
+21. **CNS Assessment** — if applicable; MRI brain at baseline and per SoA
+22. **Disease Progression** — emitted at the first PD assessment
+23. **Disposition (DS)** — randomization milestone + EOT event
+24. **End of Treatment Assessment** — summary at EOT
+25. **Subsequent Therapy (SU)** — post-progression treatment received
+26. **Survival Follow-Up** — PFS / OS endpoint emission
+
+Add or remove forms based on the trial's SoA. Document additions with
+their protocol-section reference.
+
+---
+
+## CDISC compliance notes
+
+- USUBJID: unique across study; use `{STUDY}-{SITE}-{SUBJ:04d}`
+- Date format: ISO 8601 (`YYYY-MM-DD`)
+- Visit numbering: integer monotone in study day
+- ARMCD: short code (≤8 chars); ARM: full text
+- Use SDTM-style domain prefixes for variable names where possible
+- R implementation:
+  - Generate source CRFs first, then derive SDTM/ADaM deterministically.
+  - Use `sdtm.oak` patterns for source-to-SDTM mappings where possible.
+  - Use `admiral` for ADaM derivations from SDTM/source domains.
+  - Use `xportr` and/or `datasetjson` only after final datasets pass DAG
+    and standards validation.
+
+---
+
+## SoA-to-form crosswalk (one row per visit × form combination)
+
+| Visit | Demographics | Cancer Hx | Vitals | ECG | Labs Heme | Labs Chem | ECOG | Tumor Assess | AE | Conmeds | EX | RS | DS |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| SCREENING | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |  | ✓ |  |  | ✓ |
+| C1D1 |  |  | ✓ | ✓ | ✓ | ✓ | ✓ |  | ✓ | ✓ | ✓ |  |  |
+| C1D8 |  |  | ✓ |  | ✓ |  |  |  | ✓ | ✓ | ✓ |  |  |
+| ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... | ... |
+
+This crosswalk is the deliverable that drives the simulator's per-visit
+form generation logic.

--- a/clinical-trial-ipd-sim/templates/scm_spec_template.md
+++ b/clinical-trial-ipd-sim/templates/scm_spec_template.md
@@ -1,0 +1,388 @@
+# SCM Specification — {TRIAL_NAME} (NCT{NCTID})
+
+This template enforces the level of rigor required for an identified
+g-formula causal simulation. Every variable must have its **role** in the
+DAG, its **mechanistic justification**, its **structural equation with
+full distributional specification**, and its **identifiability
+assumptions** documented. Skipping fields produces shallow SCMs that
+cannot support causal claims.
+
+> **Rule of thumb:** if the entry for a variable is shorter than three
+> bullets and lacks an evidence citation, the SCM for that variable is
+> not yet specified.
+
+---
+
+## 0 · Global causal framing
+
+Before listing variables, document the trial-level causal question:
+
+| Field | Specification |
+|---|---|
+| Target estimand | e.g. ATE on PFS, ITT vs per-protocol, intercurrent-event handling per ICH E9(R1) |
+| Causal contrast | `E[Y(A=1) − Y(A=0)]` for which population and time horizon |
+| Identifying assumptions | (1) Consistency — `Y = Y(a)` for the assigned arm. (2) Exchangeability — `Y(a) ⊥ A ∣ L₀` (randomization). (3) Positivity — `0 < P(A=a∣L₀) < 1`. (4) No interference between subjects (SUTVA). State which are by-design vs. assumed. |
+| Time-varying confounding | Are there post-baseline `Lₜ` that affect both subsequent treatment decisions (e.g., dose modifications) AND the outcome? If yes, g-formula structure is mandatory; document the recursive identification. |
+| Selection / censoring mechanism | Coarsening assumption (typically MAR given observed `Lₜ`); document any informative censoring (e.g., death after treatment discontinuation in PFS analysis) |
+| Effect modification of interest | Stratifiers from the protocol (TP53, EGFR type, race, etc.) — which subgroup contrasts must be reproduced |
+| Sensitivity analyses planned | E-value benchmarks; tipping-point analysis for unmeasured confounders |
+
+---
+
+## 1 · Variable taxonomy
+
+For every variable in the CRF, classify it on **all** axes below. The
+roles cascade into the structural equation form.
+
+| Axis | Possible values |
+|---|---|
+| Causal role | Exposure / Outcome / Confounder / Mediator / Collider / Instrument / Intermediate (time-varying) / Latent (frailty/random effect) |
+| Time index | Baseline (t=0) / Time-varying (t≥1) / Endpoint (Yₜ) / Static latent |
+| Observability | Observed / Partially observed / Latent |
+| Distributional support | Continuous / Count / Binary / Categorical / Ordinal / Time-to-event |
+| Measurement model | Direct / Derived (deterministic from parents) / Reported with detection probability |
+| Missingness mechanism | MCAR / MAR / MNAR (with the conditioning set required) |
+| Treatment effect pathway | On the causal pathway from A→Y? Direct vs mediated effect? |
+
+---
+
+## 2 · DAG specification — per-variable dossier
+
+For **every** variable, complete this template. Vague entries
+("standard distribution", "drug effect") fail review.
+
+### Template
+
+```
+### Variable: <NAME>
+
+- **Layer**: L₀ / A / Lₜ / Yₜ / latent
+- **Role**: <from taxonomy>
+- **Domain**: <support, units>
+- **Parents (DAG)**: <complete list — direct causes only>
+  - <parent1>: justification and edge type (causal / definitional / measurement)
+  - <parent2>: ...
+- **Non-parents that might naively look like parents**: <variables that
+  share an unmeasured common cause but do NOT have a direct edge here>
+  - e.g. ANC and HGB share `f_heme` but neither is a direct parent of the
+    other; they are sibling effects of the chemo×frailty interaction.
+- **Mechanistic justification**: <2–4 sentences with biological /
+  pharmacological reasoning>
+- **Functional form**:
+  - Link function: <identity / log / logit / log-log / probit / softmax>
+  - Equation:
+    ```
+    NAME[t] = link⁻¹( β₀ + Σ βᵢ·parentᵢ + γ·interaction + frailty + εₜ )
+    εₜ ~ <distribution>(scale parameters)
+    ```
+  - Alternative parameterizations considered and rejected (with reason)
+- **Parameter priors** (with full distributional spec):
+  | Parameter | Prior distribution | Central value | 95% range | Source |
+  |---|---|---|---|---|
+  | β₀ | `Normal(μ, σ²)` | x | [a, b] | PMID / CTGov field path |
+  | β_arm | `Normal(...)` | x | [a, b] | meta-analytic HR |
+  | σ_residual | `HalfNormal(...)` | x | [a, b] | repeated-measures variance estimate |
+- **Time-varying parents (if any)**:
+  - List `Lₜ₋₁` parents
+  - Lag structure: AR(1) / AR(p) / kernel
+  - Parameter ID for autoregressive coefficient α
+- **Latent frailty contribution**:
+  - Which `f_*` enters this equation
+  - Loading coefficient (with prior)
+- **Deterministic constraints / clipping**:
+  - Lower/upper bounds, monotonicity, conservation laws
+- **Detection / reporting model** (if applicable):
+  - `P(reported ∣ value, parents)` — reporting probability schedule
+  - This is a separate causal node from the underlying value
+- **Effect modification**:
+  - Which other variables modify the effect of parents on this node
+  - Interaction terms in the equation
+- **Identifiability check**:
+  - Is the full conditional distribution `P(NAME ∣ pa(NAME))` identified
+    from the observed data plus the assumed structure?
+  - If not, what additional assumptions or auxiliary data are required?
+- **d-separation implications**:
+  - Backdoor paths through this variable that must be blocked for the
+    target estimand
+  - Conditioning sets that introduce collider bias
+- **Validation gate** (post-simulation):
+  - Marginal distribution check
+  - Conditional check vs parents
+  - Sensitivity check vs alternative parameterizations
+- **Evidence dossier** (≥2 citations for non-trivial edges):
+  | Claim | Source | Effect size | Population | Limitation |
+  |---|---|---|---|---|
+  | Edge X→Y exists | PMID xxx | HR=1.4 | NSCLC adv. | Retrospective |
+```
+
+---
+
+## 3 · Layer L₀ — Baseline (one block per variable)
+
+Use the template above. Required L₀ variables for any oncology trial:
+
+- Demographics: `age`, `sex`, `race`, `country` (parents to disease and labs)
+- Disease: `histology`, `stage`, `metastatic_sites` (parents to tumor burden)
+- Biomarkers from stratification: e.g. `EGFR_type`, `TP53_status`, `PD-L1`
+- Comorbidities (parents to baseline labs and ECOG): age-driven
+- Baseline labs: `ANC₀`, `HGB₀`, `PLT₀`, `ALT₀`, `CREAT₀`, etc.
+- Baseline tumor: `baseline_SLD`, `n_target_lesions`
+- Baseline performance: `ECOG₀`
+- **Latent frailties** (mandatory section — see §5)
+- **Time-to-resistance** (a baseline-drawn latent that drives the entire
+  longitudinal tumor process; document its parents on stratifiers)
+
+> **Identifiability note**: every L₀ variable that is not directly
+> measured must either be marginalized over or set to a defensible
+> empirical Bayes prior. Document which.
+
+---
+
+## 4 · Layer A — Treatment assignment
+
+```
+### Variable: arm
+
+- Layer: A
+- Role: Exposure
+- Domain: {0=mono, 1=combo} (or per-protocol arms)
+- Parents: ∅ (by randomization design)
+- Mechanistic justification: 1:1 stratified randomization per protocol §X
+- Functional form: `arm ~ Bern(p_combo = 0.5)` independently across patients
+- Identifiability: by-design exchangeability conditional on stratifiers
+- Stratification factors (must be conditioned on for ITT analysis):
+  - <list from CTGov design module>
+```
+
+---
+
+## 5 · Latent frailties — mandatory rigor section
+
+Latent frailties are the most error-prone part of the SCM. They induce
+within-patient correlation across AE types and lab values that no purely
+arm-conditioned model can reproduce. Specify them with the same rigor as
+observed variables.
+
+For **each** frailty:
+
+```
+### Frailty: f_<NAME>
+
+- Cluster: <which AE types or lab values share this latent>
+- Distribution: `Normal(0, σ²)` — justify assumption of zero mean
+  (re-centering of fixed effects) and homoscedasticity
+- σ prior: <distribution and reference for the variance>
+- Loading on each child variable: <coefficient with prior>
+- Identifiability:
+  - Is σ identified from the observed within-patient correlation alone?
+  - What is the minimum number of repeated measures per patient needed?
+  - Is there confounding with measurement error?
+- Joint structure across frailties: are `f_heme`, `f_GI`, etc. modeled
+  as independent or with a covariance? Justify.
+- Equivalence to alternative formulations: GLMM random intercept, copula,
+  factor model — note which is being implemented and why.
+```
+
+> **Frailty trap**: setting σ = 0 to "remove a correlation" is a
+> structural change, not a calibration. It eliminates the correlation
+> entirely rather than tuning its strength. The SCM must declare which
+> frailty variances are tunable parameters and which are structurally
+> required to be > 0.
+
+---
+
+## 6 · Layer Lₜ — Time-varying state
+
+Per-variable dossier (template in §2). Required dossiers:
+
+### 6.1 Lab values (AR(p) with treatment effects + frailty)
+
+For each lab (`ANC`, `HGB`, `PLT`, `ALT`, `CREAT`, `QTcF`, …):
+
+- Document the **steady-state value during chemo** with frailty=0:
+  `x* = baseline − drag/(1−α)` for AR(1). The team must verify this
+  steady state is biologically plausible *before* running the simulator.
+- Document the lag structure and any deterministic resets at cycle start.
+- Specify the **measurement error** separately from the **process noise**.
+
+### 6.2 Tumor / RECIST
+
+- `SLD[t]` mechanistic model: shrinkage kinetics (rate constant `k`),
+  asymptotic depth of response (per arm), time-to-resistance switch,
+  post-resistance growth rate `g`. All parameters require priors.
+- Resistance kinetics: hazard model for time-to-resistance (Weibull
+  shape and scale), parents (arm, biomarkers, tumor frailty). The
+  Weibull shape governs whether resistance is approximately memoryless
+  (k≈1) or accelerating (k>1) — choose based on biology.
+- New-lesion process: separate Poisson / Bernoulli per visit with arm-
+  and resistance-dependent intensity.
+- Response classification (RECIST 1.1): **deterministic function** of
+  SLD trajectory and new lesions. This is part of the SCM but never
+  tuned — only the inputs to it are.
+- Confirmation rule: requires consecutive scans for CR/PR; document
+  how confirmation latency affects PFS timing.
+
+### 6.3 Adverse events
+
+For **every** AE preferred term in the published trial table:
+
+- **Generation mechanism**: deterministic from a state variable (lab-grade)
+  or hazard-driven (frailty + arm).
+- For deterministic AEs (Neutropenia, Anemia, Thrombocytopenia, hepatic):
+  - The CTCAE thresholds are fixed (do not parameterize).
+  - The reporting probability schedule `P(reported ∣ grade)` IS a parameter.
+  - Document the assumed reporting model — most trials under-report Gr 1.
+- For hazard-driven AEs (rash, diarrhea, ILD, etc.):
+  - Per-visit hazard `λ(parents) = exp(log_haz_base + β_arm + f_cluster + β_recurrence)`
+  - Each coefficient needs a prior.
+  - Document the exposure window (on-treatment vs follow-up).
+  - Document recurrence: is the AE absorbing (ILD), recurrent (rash), or
+    transient (acute nausea)?
+- **Severity given event**: a separate parameter `p_severe` per AE. Do
+  not collapse "incidence" and "severity" into one knob — they have
+  different mechanistic determinants.
+- **Action taken**: dose-modification action is downstream of grade; do
+  not let it be a fresh random draw uncorrelated with grade.
+
+### 6.4 Dose modifications
+
+- Strictly rule-based per protocol's dose-mod table. Dose modifications
+  are descendants of AEs; never make them parents of AEs.
+- Document the protocol's hold/resume/withdraw thresholds.
+
+### 6.5 ECOG performance status
+
+- Bivariate transition model `ECOG[t] ∣ ECOG[t−1], recent_g3, progressed`
+- ECOG is on the causal pathway from AE burden to discontinuation.
+
+### 6.6 Discontinuation
+
+- Hazard model with parents: recent severe AEs, ILD, progression,
+  ECOG decline, frailty `f_dropout`.
+- Document the censoring model: administrative cutoff vs. early
+  discontinuation. PFS analyses typically continue follow-up post
+  treatment discontinuation; OS analyses always do.
+
+---
+
+## 7 · Layer Yₜ — Endpoints (deterministic from trajectory)
+
+Endpoints are **never** independently sampled. They are deterministic
+functionals of the trajectory.
+
+```
+### Endpoint: PFS_DAY
+
+- Definition: `min(progression_day, death_day, ADMIN_CENSOR_DAY)`
+- Where `progression_day` = first scan visit at which RECIST PD criteria
+  met (per the simulated SLD trajectory and new-lesion process)
+- Where `death_day` = if simulated within follow-up; otherwise None
+- ADMIN_CENSOR_DAY: data-cutoff date from CTGov results record
+- Identifiability: by construction; no additional assumption beyond the
+  trajectory's identifying structure
+- Validation gate: corr(PFS_DAY, progression_day) = 1.0 for patients with
+  observed progression; events strictly before censor mean PFS_EVENT=1
+```
+
+Any deviation from this rule (e.g., drawing PFS_TIME from a Weibull
+conditioned on arm) collapses the SCM to a marginal model and forfeits
+all causal claims. Document explicitly that this is not done.
+
+---
+
+## 8 · Time-varying confounding diagram (mandatory)
+
+Draw the per-time-step DAG showing how `Lₜ` influences subsequent
+treatment decisions and outcomes. For a typical oncology trial:
+
+```
+A ──→ L₁ ──→ L₂ ──→ ... ──→ Y
+│      │      │              │
+└──────┴──────┴──────────────┘  (direct A → Lₜ for each t)
+       │      │
+       └──→ Aₜ (dose modifications)  ← time-varying treatment
+              │
+              └──→ Lₜ₊₁
+```
+
+Document:
+- Which `Lₜ` nodes affect dose modifications (`Aₜ`, t≥1) — these are
+  time-varying confounders requiring g-formula adjustment.
+- Whether the per-protocol estimand requires inverse-probability
+  weighting for treatment changes, or whether intention-to-treat
+  ignores them.
+- Whether the dropout process is conditional on observed `Lₜ` (MAR;
+  g-formula handles this) or on unobserved factors (MNAR; sensitivity
+  analysis required).
+
+---
+
+## 9 · Effect-modification specification
+
+For each pre-specified subgroup analysis in the trial:
+
+| Subgroup variable | Expected effect modification | Mechanism | Reference |
+|---|---|---|---|
+| `tp53_status` | TP53-mut: HR vs combo attenuated by ≈0.1 | TP53 alters response duration | PMID xxx |
+| `egfr_type` | Ex19del: deeper response than L858R | Ligand-binding affinity | PMID xxx |
+| `cns_mets` | CNS+: shorter PFS | CNS sanctuary, drug penetration | PMID xxx |
+
+The SCM must reproduce these subgroup contrasts with effect sizes within
+the published 95% CIs.
+
+---
+
+## 10 · Evidence dossier
+
+Every non-trivial edge requires multiple sources where possible.
+
+For each edge `X → Y`:
+
+| Field | Required content |
+|---|---|
+| Edge | `X → Y` |
+| Effect direction & magnitude | sign, point estimate, range |
+| Mechanism | biological / pharmacological / measurement |
+| Primary source | PMID with first-class evidence (RCT or large registry) |
+| Secondary sources | confirmatory citations |
+| Effect-size variability | range across populations |
+| Limitations | confounding in source studies, generalizability |
+
+---
+
+## 11 · Identifiability summary
+
+At the end of specification, produce a checklist:
+
+- [ ] **Consistency**: counterfactual outcome equals observed outcome
+  under the assigned arm — ensured by the SCM by construction.
+- [ ] **Exchangeability**: `Y(a) ⊥ A ∣ stratifiers` — ensured by the
+  randomization model in §4.
+- [ ] **Positivity**: `0 < P(A=a ∣ L₀) < 1` — verify that no L₀ stratum
+  has all patients on one arm.
+- [ ] **No interference / SUTVA** — patients are independent draws.
+- [ ] **Time-varying exchangeability**: `Y(ā) ⊥ Aₜ ∣ L̄ₜ, Āₜ₋₁` for the
+  per-protocol estimand if applicable.
+- [ ] **Coarsening at random / MAR for missingness** — given the
+  conditioning set documented per variable.
+- [ ] **No hidden direct edges from A to Y** that bypass the modeled
+  mediators.
+
+If any item is unchecked, document why (e.g., "violation expected; will
+include sensitivity analysis").
+
+---
+
+## 12 · Pre-simulation review checklist
+
+Before running step 5 (forward simulation), verify:
+
+- [ ] Every variable has a complete dossier per §2
+- [ ] DAG is acyclic (run `networkx.is_directed_acyclic_graph`)
+- [ ] All parameter priors have ≥1 cited source
+- [ ] All deterministic rules (CTCAE thresholds, RECIST 1.1) are coded
+      as functions, not parameters
+- [ ] Latent frailties have non-zero variance priors
+- [ ] No endpoint is sampled directly from a parent's distribution
+- [ ] Time-varying confounding diagram (§8) is drawn and matches code
+- [ ] Identifiability checklist (§11) is signed off


### PR DESCRIPTION
## Summary

Adds `clinical-trial-ipd-sim`, an R/pharmaverse-oriented skill for generating synthetic individual patient data for registered clinical trials from public protocol and results sources.

The skill guides agents through:
- ClinicalTrials.gov intake and protocol retrieval, with NEJM/user-provided protocol fallback
- CRF schema derivation from the protocol schedule of activities
- Evidence-backed causal DAG/SCM specification
- Parameterization from ClinicalTrials.gov results and cited priors
- G-formula forward simulation in R
- Causality-preserving calibration with DAG gates
- Source CRF, SDTM, ADaM, TLG, XPT, and Dataset-JSON output planning

## Included

- `SKILL.md`
- R implementation guide
- CRF and SCM templates
- README and license

## Testing

- Run on FLAURA2 (`NCT04035486`) end-to-end run from the skill:
  - generated an R implementation from scratch
  - fetched the ClinicalTrials.gov record and posted protocol
  - produced source CRFs, SDTM/ADaM-style outputs (not fully standardized yet)
  - all DAG gates and generated tests passed
