### PR TITLE
fix: strengthen derive_vars_merged_lookup enforcement in admiral-bds SKILL.md

### DIFF
--- a/admiral/admiral-bds/SKILL.md
+++ b/admiral/admiral-bds/SKILL.md
@@ -391,7 +391,7 @@ if (length(missing_vars) > 0) {
   `DTYPE != NA` records from uniqueness checks (synthetic rows are intentional
   duplicates by USUBJID + PARAMCD + AVISITN)
 - Using `derive_vars_merged()` instead of `derive_vars_merged_lookup()` for
-  PARAMCD/PARAM/PARAMN assignment — `derive_vars_merged()` is reserved for ADSL
+  PARAMCD/PARAM/PARAMN assignment — `derive_vars_merged()` is primarily used for ADSL
   backbone merges; parameter code mappings must use `derive_vars_merged_lookup()`
   so that unmatched records are retained and filterable via `filter(!is.na(PARAMCD))`
 - Using `"N"` for ABLFL or ANL01FL — flag convention is `"Y"` or `NA` only

--- a/admiral/admiral-bds/SKILL.md
+++ b/admiral/admiral-bds/SKILL.md
@@ -91,8 +91,10 @@ advs <- vs |>
 
 ### Step 3 — Parameter assignment
 
-Map SDTM test codes to ADaM parameters. Use a lookup table driven by the ADaM
-spec — do not use `case_when()` or hardcoded `if_else()` chains for this.
+Map SDTM test codes to ADaM parameters. Use `derive_vars_merged_lookup()` with a
+lookup table driven by the ADaM spec. Do **not** use `derive_vars_merged()` here —
+that function is for ADSL variable merges only. Do not use `case_when()` or
+hardcoded `if_else()` chains.
 
 ```r
 # REVIEW: PARAMCD mapping must match the ADaM spec parameter list exactly.
@@ -388,6 +390,10 @@ if (length(missing_vars) > 0) {
 - Asserting uniqueness without accounting for DTYPE rows — exclude
   `DTYPE != NA` records from uniqueness checks (synthetic rows are intentional
   duplicates by USUBJID + PARAMCD + AVISITN)
+- Using `derive_vars_merged()` instead of `derive_vars_merged_lookup()` for
+  PARAMCD/PARAM/PARAMN assignment — `derive_vars_merged()` is reserved for ADSL
+  backbone merges; parameter code mappings must use `derive_vars_merged_lookup()`
+  so that unmatched records are retained and filterable via `filter(!is.na(PARAMCD))`
 - Using `"N"` for ABLFL or ANL01FL — flag convention is `"Y"` or `NA` only
 - Deriving ANRIND from AVAL without a `# REVIEW:` comment — normal range logic
   is almost always protocol-specific
@@ -400,7 +406,7 @@ Before returning code, verify:
 
 - [ ] ADSL variables (TRTSDT, population flags) merged before baseline derivation
 - [ ] DOMAIN removed from source domain before `derive_vars_merged()` calls
-- [ ] PARAMCD mapping sourced from spec lookup table, not `case_when()`
+- [ ] PARAMCD/PARAM/PARAMN assigned with `derive_vars_merged_lookup()` — not `derive_vars_merged()`, not `case_when()`
 - [ ] ADT derived with `derive_vars_dt()`, not `as.Date()` on VSDTC/LBDTC
 - [ ] ADY derived with `derive_vars_dy()`
 - [ ] AVISIT assigned from spec-driven visit map

--- a/admiral/admiral-bds/SKILL.md
+++ b/admiral/admiral-bds/SKILL.md
@@ -93,7 +93,7 @@ advs <- vs |>
 
 Map SDTM test codes to ADaM parameters. Use `derive_vars_merged_lookup()` with a
 lookup table driven by the ADaM spec. Do **not** use `derive_vars_merged()` here —
-that function is for ADSL variable merges only. Do not use `case_when()` or
+it is not a lookup function and will not correctly handle unmatched records. Do not use `case_when()` or
 hardcoded `if_else()` chains.
 
 ```r


### PR DESCRIPTION
## Summary
Benchmark evaluations for issues #147 and #149 both show the skill agent substituting `derive_vars_merged()` for `derive_vars_merged_lookup()` when assigning PARAMCD/PARAM/PARAMN, causing assertion failures despite the existing lookup-table instruction. Three reinforcements added to close this gap.

## Benchmark evidence
| Issue | Skill score | Failing assertion |
|---|---|---|
| #147 | 88.2% | `derive_vars_merged_lookup()` used for parameter assignment |
| #149 | 94.4% | `derive_vars_merged_lookup()` used for parameter assignment |

In both runs the agent correctly built a `param_lookup` tibble but then called `derive_vars_merged()` instead of `derive_vars_merged_lookup()`, likely by pattern-matching from the Step 2 ADSL merge.

## Changes
- **Step 3 prose**: names `derive_vars_merged_lookup()` as required and explicitly bans `derive_vars_merged()` for parameter assignment
- **Common BDS errors**: new bullet explains why the functions differ
- **Output checklist**: strengthens the PARAMCD item to exclude both `derive_vars_merged()` and `case_when()` by name

## Test plan
- [x] Re-run benchmark for #147 and confirm parameter-assignment assertion passes
- [x] Re-run benchmark for #149 and confirm parameter-assignment assertion passes
- [x] Confirm no regression on #148