### PR TITLE
Add pilot7-weekly-summary automation skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ clinical-trial-simulation/**/*.html
 
 # Local /simulate launcher (per-user; do not ship)
 /.claude/commands/simulate.md
+
+# Weekly-summary skill output — generated per run, posted to Slack, not committed
+/outputs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ pharma_skills/
 ├── _automation/               ← Automation skills (see below)
 │   ├── benchmark-runner/      ← A/B benchmark orchestration
 │   ├── issue-to-eval/         ← GitHub Issue → evals.json converter
-│   └── weekly-summary/        ← Weekly activity → Slack
+│   ├── weekly-summary/        ← Weekly activity → Slack
+│   └── pilot7-weekly-summary/ ← Pilot 7 weekly activity → Slack (Friday)
 └── .github/
     ├── ISSUE_TEMPLATE/benchmark.md  ← Template for benchmark issues
     └── workflows/             ← CI: skill validation + benchmark scheduling
@@ -38,6 +39,7 @@ pharma_skills/
 | `benchmark-summary` | "update the benchmark summary", "generate benchmark analysis", "summarize skill vs no-skill results", "add failure patterns", produce `benchmark_analysis_*.md` |
 | `issue-to-eval` | "parse this issue into a benchmark", "sync all benchmark issues" |
 | `weekly-summary` | "generate weekly summary", "post to Slack" |
+| `pilot7-weekly-summary` | "pilot7 weekly update", "summarize pilot7 progress", "submissions-pilot7-synthetic-data weekly summary" |
 
 ## Agent Guardrails
 
@@ -51,6 +53,7 @@ pharma_skills/
 | Variable | Used by | Purpose |
 |---|---|---|
 | `PHARMA_SKILLS_SLACK_CHANNEL` | `weekly-summary` | Slack channel ID for posting. If unset, the skill reads from `_automation/weekly-summary/config.json`. |
+| `PILOT7_SLACK_CHANNEL` | `pilot7-weekly-summary` | Slack channel ID for posting. If unset, the skill reads from `_automation/pilot7-weekly-summary/config.json`. |
 
 ## Contributing
 

--- a/_automation/README.md
+++ b/_automation/README.md
@@ -9,6 +9,7 @@ This directory contains automated workflows for managing, evaluating, and report
 | [`benchmark-runner/`](benchmark-runner/) | **Benchmark Runner** | Runs parallel "With Skill" vs. "Without Skill" evaluations to quantify skill performance. Posts results to GitHub issues. |
 | [`issue-to-eval/`](issue-to-eval/) | **Issue to Eval** | Automatically syncs GitHub issues labeled `benchmark` into the local `_automation/evals/` directory. Supports updating existing tests if the issue content changes. |
 | [`weekly-summary/`](weekly-summary/) | **Weekly Summary** | Aggregates repository activity (commits, PRs, issues) over the last 7 days and generates a concise status update for Slack. |
+| [`pilot7-weekly-summary/`](pilot7-weekly-summary/) | **Pilot 7 Weekly Summary** | Aggregates weekly activity from `RConsortium/submissions-pilot7-synthetic-data` and posts a Friday progress update to the `#pilot7-sdtm-adam-tlf-bench` Slack channel. See its README for routine scheduling. |
 
 ## Usage
 

--- a/_automation/pilot7-weekly-summary/LICENSE
+++ b/_automation/pilot7-weekly-summary/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_automation/pilot7-weekly-summary/README.md
+++ b/_automation/pilot7-weekly-summary/README.md
@@ -1,0 +1,47 @@
+# Pilot 7 Weekly Summary
+
+Generates a weekly progress update for
+[`RConsortium/submissions-pilot7-synthetic-data`](https://github.com/RConsortium/submissions-pilot7-synthetic-data)
+and posts it to the `#pilot7-sdtm-adam-tlf-bench` Slack channel
+(`C0B44HS7CNA`).
+
+- `SKILL.md` — agent workflow instructions
+- `config.json` — target repo, Slack channel, word limit, lookback window
+- `scripts/get_weekly_data.py` — fetches commits/PRs/issues/releases from the
+  GitHub REST API (no local checkout of pilot7 required)
+
+## Running manually
+
+Point an agent at `SKILL.md`, or fetch the raw data yourself:
+
+```bash
+python3 _automation/pilot7-weekly-summary/scripts/get_weekly_data.py
+```
+
+The script works unauthenticated for the public pilot7 repo; set `GH_TOKEN`
+or `GITHUB_TOKEN` to raise the API rate limit.
+
+## Scheduling as a Claude Code Routine (Friday afternoon)
+
+Go to [claude.ai/code/routines](https://claude.ai/code/routines) → **New routine**:
+
+| Field | Value |
+|---|---|
+| **Repository** | `RConsortium/pharma-skills` |
+| **Environment** | Any environment with default network access and the Slack integration enabled (R is **not** required for this skill) |
+| **Trigger** | Schedule — weekly, **Friday at 16:00 (America/New_York)** |
+| **Prompt** | See below |
+
+Routine prompt:
+
+```
+Generate the weekly progress summary for RConsortium/submissions-pilot7-synthetic-data.
+Follow the instructions in _automation/pilot7-weekly-summary/SKILL.md exactly.
+Post the summary to the configured Slack channel.
+```
+
+After creating the routine, click **Run now** once to verify that the GitHub
+API is reachable and the summary lands in the Slack channel.
+
+To redirect the post (e.g. for testing), set `PILOT7_SLACK_CHANNEL` in the
+environment config — it overrides `slack_channel` in `config.json`.

--- a/_automation/pilot7-weekly-summary/SKILL.md
+++ b/_automation/pilot7-weekly-summary/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pilot7-weekly-summary
+description: Generate a concise weekly progress summary for the RConsortium/submissions-pilot7-synthetic-data repository and post it to the pilot7 Slack channel. Use this for the Friday weekly update on pilot7 synthetic data progress.
+---
+
+# Pilot 7 Weekly Summary Skill
+
+This skill automates a weekly progress update for the
+[`RConsortium/submissions-pilot7-synthetic-data`](https://github.com/RConsortium/submissions-pilot7-synthetic-data)
+repository (R Consortium Submissions Pilot 7 — synthetic SDTM/ADaM/TLF data),
+posted to the `#pilot7-sdtm-adam-tlf-bench` Slack channel.
+
+## Configuration
+
+Before running, read `_automation/pilot7-weekly-summary/config.json` to load:
+- `repo` — the GitHub repository to summarize
+- `max_words` — word limit for the summary (default 200)
+- `slack_channel` — Slack channel ID to post to (overridden by `PILOT7_SLACK_CHANNEL` env var)
+- `lookback_days` — how many days of activity to include (default 7)
+
+If `PILOT7_SLACK_CHANNEL` is set in the environment, it takes precedence over `config.json`.
+If neither is set, **stop and report an error** — do not guess a channel ID.
+
+## Steps
+
+1. **Research Recent Activity**
+   - Run from the repository root:
+     ```bash
+     python3 _automation/pilot7-weekly-summary/scripts/get_weekly_data.py
+     ```
+   - The script queries the GitHub REST API for the configured repo (no local
+     checkout of pilot7 is needed). Set `GH_TOKEN` or `GITHUB_TOKEN` if the
+     unauthenticated rate limit is hit.
+   - Use the JSON output to identify commits, open/closed issues,
+     merged/open PRs, and any releases published this week.
+
+2. **Generate Summary**
+   - Write a summary under `max_words` words (from config) in Slack mrkdwn format,
+     aimed at the pilot7 working group (statisticians and statistical programmers).
+   - Use the following structure:
+     *🧪 submissions-pilot7-synthetic-data — week of [DATE]*
+     • *Commits:* [count + contributors + one-line highlight]
+     • *PRs:* [merged/open count + key change, e.g. data generation, P21 fixes]
+     • *Issues:* [opened/closed count + notable item]
+     • *Releases:* [tag + name, only if any were published]
+     • *TL;DR:* [1–2 sentences on overall momentum and what to watch next week]
+   - Skip any section with no activity. If the whole week had no activity,
+     post a single line saying so rather than an empty skeleton.
+   - Link PR/issue numbers to their GitHub URLs
+     (e.g. `<https://github.com/RConsortium/submissions-pilot7-synthetic-data/pull/47|#47>`).
+   - Be direct and terse.
+
+3. **Slack Output**
+   - Read the Slack channel from the environment variable `PILOT7_SLACK_CHANNEL`,
+     falling back to `slack_channel` in `config.json`.
+   - Post the summary to that channel using an available Slack integration tool.
+
+4. **File Output**
+   - Save the summary as a markdown file:
+     `/sessions/[session-dir]/mnt/outputs/pilot7-weekly-summary-[YYYY-MM-DD].md`
+     (or `outputs/pilot7-weekly-summary-[YYYY-MM-DD].md` if no session mount exists —
+     do **not** commit this file to the repo).
+   - Output the path to the saved file so the user can review it.

--- a/_automation/pilot7-weekly-summary/config.json
+++ b/_automation/pilot7-weekly-summary/config.json
@@ -1,0 +1,6 @@
+{
+  "repo": "RConsortium/submissions-pilot7-synthetic-data",
+  "max_words": 200,
+  "slack_channel": "C0B44HS7CNA",
+  "lookback_days": 7
+}

--- a/_automation/pilot7-weekly-summary/scripts/get_weekly_data.py
+++ b/_automation/pilot7-weekly-summary/scripts/get_weekly_data.py
@@ -1,0 +1,124 @@
+"""Collect weekly activity data for the repo configured in config.json.
+
+Unlike weekly-summary/scripts/get_weekly_data.py, this script targets a
+remote repository (it does not assume a local checkout), so all data is
+fetched from the GitHub REST API. Works unauthenticated for public repos;
+set GH_TOKEN or GITHUB_TOKEN to raise the rate limit or access private repos.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.json"
+API_ROOT = "https://api.github.com"
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def api_get(path: str, params: dict | None = None):
+    """GET a GitHub API path and return parsed JSON. Exit with error on failure."""
+    url = f"{API_ROOT}{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(url)
+    request.add_header("Accept", "application/vnd.github+json")
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode())
+    except (urllib.error.URLError, json.JSONDecodeError) as e:
+        print(f"Error: GitHub API request failed: {url}\n{e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_weekly_data() -> dict:
+    config = load_config()
+    repo: str = config["repo"]
+    lookback_days: int = config.get("lookback_days", 7)
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=lookback_days)
+    since_date = since.strftime("%Y-%m-%d")
+
+    commits = api_get(
+        f"/repos/{repo}/commits",
+        {"since": since.strftime("%Y-%m-%dT%H:%M:%SZ"), "per_page": 100},
+    )
+    commits_summary = [
+        {
+            "sha": c["sha"][:7],
+            "message": c["commit"]["message"].split("\n")[0],
+            "author": (c.get("author") or {}).get("login")
+            or c["commit"]["author"]["name"],
+        }
+        for c in commits
+    ]
+
+    issues_result = api_get(
+        "/search/issues",
+        {"q": f"repo:{repo} is:issue updated:>={since_date}", "per_page": 100},
+    )
+    issues_summary = [
+        {"number": i["number"], "title": i["title"], "state": i["state"]}
+        for i in issues_result.get("items", [])
+    ]
+
+    prs_result = api_get(
+        "/search/issues",
+        {"q": f"repo:{repo} is:pr updated:>={since_date}", "per_page": 100},
+    )
+    prs_summary = [
+        {
+            "number": pr["number"],
+            "title": pr["title"],
+            "state": pr["state"],
+            "merged": bool((pr.get("pull_request") or {}).get("merged_at")),
+        }
+        for pr in prs_result.get("items", [])
+    ]
+
+    releases = api_get(f"/repos/{repo}/releases", {"per_page": 20})
+    releases_summary = [
+        {"tag": r["tag_name"], "name": r["name"], "published_at": r["published_at"]}
+        for r in releases
+        if r.get("published_at") and r["published_at"] >= since.strftime("%Y-%m-%dT%H:%M:%SZ")
+    ]
+
+    return {
+        "repo": repo,
+        "week_starting": since_date,
+        "week_ending": now.strftime("%Y-%m-%d"),
+        "commits": {
+            "total_count": len(commits_summary),
+            "authors": sorted({c["author"] for c in commits_summary}),
+            "highlights": commits_summary[:10],
+        },
+        "issues": {
+            "total_updated": len(issues_summary),
+            "list": issues_summary,
+        },
+        "pull_requests": {
+            "total_updated": len(prs_summary),
+            "list": prs_summary,
+        },
+        "releases": {
+            "total_published": len(releases_summary),
+            "list": releases_summary,
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(get_weekly_data(), indent=2))

--- a/_automation/tests/test_pilot7_weekly_summary.py
+++ b/_automation/tests/test_pilot7_weekly_summary.py
@@ -1,0 +1,116 @@
+"""
+Unit tests for _automation/pilot7-weekly-summary/scripts/get_weekly_data.py
+"""
+
+import importlib.util
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+# Load under a unique module name: weekly-summary's tests also import a module
+# called get_weekly_data, and a plain `import` would collide in sys.modules.
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "pilot7-weekly-summary" / "scripts" / "get_weekly_data.py"
+)
+_spec = importlib.util.spec_from_file_location("pilot7_get_weekly_data", SCRIPT_PATH)
+p7 = importlib.util.module_from_spec(_spec)
+sys.modules["pilot7_get_weekly_data"] = p7
+_spec.loader.exec_module(p7)
+
+
+class TestLoadConfig(unittest.TestCase):
+    def test_returns_defaults_when_no_file(self):
+        with patch("pilot7_get_weekly_data.CONFIG_PATH") as mock_path:
+            mock_path.exists.return_value = False
+            config = p7.load_config()
+        self.assertEqual(config, {})
+
+    def test_repo_config_checked_in(self):
+        # The committed config must point at the pilot7 repo and Slack channel.
+        config = p7.load_config()
+        self.assertEqual(config["repo"], "RConsortium/submissions-pilot7-synthetic-data")
+        self.assertEqual(config["slack_channel"], "C0B44HS7CNA")
+
+
+class TestGetWeeklyData(unittest.TestCase):
+    @patch(
+        "pilot7_get_weekly_data.load_config",
+        return_value={"repo": "RConsortium/submissions-pilot7-synthetic-data", "lookback_days": 7},
+    )
+    @patch("pilot7_get_weekly_data.api_get")
+    def test_structure(self, mock_api, _):
+        recent = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        commits = [
+            {
+                "sha": "abcdef1234567",
+                "commit": {"message": "feat: add eCRF-based generation\n\nbody", "author": {"name": "Zifeng"}},
+                "author": {"login": "zifengwang"},
+            }
+        ]
+        issues = {"items": [{"number": 10, "title": "MedDRA mapping", "state": "open"}]}
+        prs = {
+            "items": [
+                {
+                    "number": 47,
+                    "title": "Rerun P21 fixes",
+                    "state": "closed",
+                    "pull_request": {"merged_at": recent},
+                }
+            ]
+        }
+        releases = [
+            {"tag_name": "v0.2.0", "name": "v0.2.0", "published_at": recent},
+            {"tag_name": "v0.1.0", "name": "v0.1.0", "published_at": "2020-01-01T00:00:00Z"},
+        ]
+        mock_api.side_effect = [commits, issues, prs, releases]
+
+        data = p7.get_weekly_data()
+        self.assertEqual(data["repo"], "RConsortium/submissions-pilot7-synthetic-data")
+        self.assertEqual(data["commits"]["total_count"], 1)
+        self.assertEqual(data["commits"]["highlights"][0]["sha"], "abcdef1")
+        self.assertEqual(
+            data["commits"]["highlights"][0]["message"],
+            "feat: add eCRF-based generation",
+        )
+        self.assertEqual(data["issues"]["total_updated"], 1)
+        self.assertTrue(data["pull_requests"]["list"][0]["merged"])
+        # Only the release published inside the lookback window is included
+        self.assertEqual(data["releases"]["total_published"], 1)
+        self.assertEqual(data["releases"]["list"][0]["tag"], "v0.2.0")
+
+    @patch(
+        "pilot7_get_weekly_data.load_config",
+        return_value={"repo": "RConsortium/submissions-pilot7-synthetic-data", "lookback_days": 14},
+    )
+    @patch("pilot7_get_weekly_data.api_get")
+    def test_lookback_days_from_config(self, mock_api, _):
+        mock_api.side_effect = [[], {"items": []}, {"items": []}, []]
+        data = p7.get_weekly_data()
+        expected_start = (datetime.now(timezone.utc) - timedelta(days=14)).strftime("%Y-%m-%d")
+        self.assertEqual(data["week_starting"], expected_start)
+        self.assertEqual(data["commits"]["total_count"], 0)
+        self.assertEqual(data["releases"]["total_published"], 0)
+
+    @patch(
+        "pilot7_get_weekly_data.load_config",
+        return_value={"repo": "RConsortium/submissions-pilot7-synthetic-data"},
+    )
+    @patch("pilot7_get_weekly_data.api_get")
+    def test_commit_author_falls_back_to_name(self, mock_api, _):
+        commits = [
+            {
+                "sha": "1234567abcdef",
+                "commit": {"message": "fix typo", "author": {"name": "Peng Zhang"}},
+                "author": None,
+            }
+        ]
+        mock_api.side_effect = [commits, {"items": []}, {"items": []}, []]
+        data = p7.get_weekly_data()
+        self.assertEqual(data["commits"]["highlights"][0]["author"], "Peng Zhang")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new automation skill `pilot7-weekly-summary` that generates weekly progress summaries for the RConsortium/submissions-pilot7-synthetic-data repository and posts them to Slack. This complements the existing `weekly-summary` skill by targeting a specific repository with a dedicated workflow.

## Key Changes

- **New skill: `_automation/pilot7-weekly-summary/`**
  - `SKILL.md` — Agent workflow instructions for generating and posting weekly summaries
  - `README.md` — Setup and scheduling guide for Claude Code Routines
  - `config.json` — Configuration for target repo, Slack channel, word limit, and lookback window
  - `scripts/get_weekly_data.py` — Python script that fetches commits, PRs, issues, and releases from the GitHub REST API (no local checkout required)
  - `LICENSE` — MIT license

- **Test coverage: `_automation/tests/test_pilot7_weekly_summary.py`**
  - Unit tests for config loading, API integration, and data structure validation
  - Tests verify correct handling of commits, issues, PRs, releases, and author fallback logic
  - Tests confirm the committed config points to the correct repo and Slack channel

- **Documentation updates**
  - Updated `CLAUDE.md` to list the new skill in the directory structure and available skills table
  - Updated `_automation/README.md` to document the new skill
  - Updated `.gitignore` to exclude generated weekly-summary output files

## Implementation Details

- `get_weekly_data.py` uses the GitHub REST API (no local git checkout needed) and supports both authenticated (via `GH_TOKEN` or `GITHUB_TOKEN`) and unauthenticated access
- Configurable lookback window (default 7 days) to capture activity within a specified time range
- Extracts and summarizes commits (with author fallback to commit author name if GitHub user login unavailable), issues, PRs (with merge status), and releases
- Designed to be invoked by Claude Code agents following the SKILL.md workflow to generate Slack-formatted summaries
- Scheduled for Friday afternoon posting via Claude Code Routines

https://claude.ai/code/session_016xFMZ7EVGhbgaGcji2Qv6p