### PR TITLE
benchmark-runner: parent and sub-agents must use the same model

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -11,6 +11,18 @@ Repository: `RConsortium/pharma-skills` (https://github.com/RConsortium/pharma-s
 
 ---
 
+## Model Selection — Parent and Sub-Agents Use the Same Model
+
+`{CURRENT_MODEL_NAME}` throughout this skill means the canonical API model ID of the **parent (orchestrating) agent** — the session executing this SKILL.md. Resolve it once at startup and use it everywhere it appears: `get_next_eval.py --model`, both `claude -p --model` launches, the marker JSON, and the report metadata.
+
+Rules:
+
+- Agent A and Agent B MUST be launched with exactly the parent's model ID (`claude -p --model "{CURRENT_MODEL_NAME}"`). Never select a different model for the sub-agents and never hardcode a model name — the benchmark series being extended is the parent model's own series.
+- The model ID — together with the prompt files constructed in Step 2 / Step 6 and the `CLAUDE_CODE_MAX_OUTPUT_TOKENS` setting — is the **only** information passed from the parent session to a sub-agent. Do not forward any other parent context: no conversation history, no additional environment variables, no eval assertions, no scoring prompt, no blinded map. This keeps the measurement clean (bare model ± skill) and prevents the orchestrator's context from leaking into either candidate.
+- If the parent's model ID cannot be determined, or cannot be truthfully recorded in the public issue-comment markers (e.g., the host environment withholds or embargoes its model identity), **exit cleanly without launching agents or posting comments**. Do not run the benchmark under a substituted model ID: markers carrying a model name that did not actually produce the outputs corrupt deduplication and the scorecard history for every other runner.
+
+---
+
 ## Routine Setup (one-time)
 
 Create a single routine at [claude.ai/code/routines](https://claude.ai/code/routines):
@@ -205,7 +217,7 @@ Write the partial comment body to `/tmp/partial_comment_{eval_id}.md`:
 |---|---|
 | **Eval ID** | `{id}` |
 | **Run date** | {YYYY-MM-DD HH:MM UTC} |
-| **Model** | `claude-sonnet-4-6` |
+| **Model** | `{CURRENT_MODEL_NAME}` |
 | **Skill version** | `{_skill_sha[:7]}` |
 | **Phase** | 1 of 2 complete — Agent A (with skill) finished |
 
@@ -466,7 +478,10 @@ EVERY ROUTINE INVOCATION:
 
 ## Notes on Model Name
 
+`{CURRENT_MODEL_NAME}` is always the parent agent's own model — see "Model Selection — Parent and Sub-Agents Use the Same Model" at the top of this skill.
+
 Pass `--model` using the canonical API model ID (e.g., `claude-sonnet-4-6` or `gemini-3.1-pro-preview`), not the display name. The deduplication logic normalises both sides, but using the API ID avoids ambiguity.
+* **For Claude Code:** Read the model ID from your system prompt / environment context (e.g., `claude-sonnet-4-6`) if you don't already know it.
 * **For Gemini CLI:** Read the **Runtime Context** block injected into your system prompt to find the `Active Model` (e.g., `gemini-3-pro-preview`) if you don't already know it.
 
 ## Notes on Distributed Selection

--- a/admiral-adae
+++ b/admiral-adae
@@ -1,0 +1,1 @@
+admiral/admiral-adae

--- a/admiral-adsl
+++ b/admiral-adsl
@@ -1,0 +1,1 @@
+admiral/admiral-adsl

--- a/admiral-bds
+++ b/admiral-bds
@@ -1,0 +1,1 @@
+admiral/admiral-bds


### PR DESCRIPTION
## Summary

Codifies the model-selection policy for the benchmark runner: **the benchmarked sub-agents (Agent A and Agent B) must run on the same model as the parent (orchestrating) agent.**

### SKILL.md changes

- New section **"Model Selection — Parent and Sub-Agents Use the Same Model"** defining `{CURRENT_MODEL_NAME}` as the parent agent's own canonical API model ID, resolved once at startup and used consistently in `get_next_eval.py --model`, both `claude -p --model` launches, the marker JSON, and report metadata.
- The model ID — together with the constructed prompt files and the `CLAUDE_CODE_MAX_OUTPUT_TOKENS` cap — is the **only** information forwarded from the parent session to a sub-agent. No conversation history, extra environment variables, eval assertions, scoring prompt, or blinded map may leak into either candidate, keeping the measurement a clean bare-model ± skill comparison.
- If the parent's model ID cannot be determined, or cannot be truthfully recorded in the public issue-comment markers, the runner now **exits without launching agents or posting comments** instead of substituting another model — markers carrying a model name that didn't actually produce the outputs would corrupt deduplication for every other runner.
- Fixes the Step 4 partial-comment template, which hardcoded `claude-sonnet-4-6` in the **Model** row instead of `{CURRENT_MODEL_NAME}`.

### Also included

- Repo-root symlinks `admiral-adsl`, `admiral-adae`, `admiral-bds` → `admiral/…`. Eval cases reference `target_skills` by the bare skill name, but `get_next_eval.py` resolves `REPO_ROOT/{target_skill}/SKILL.md`, so ten admiral evals were silently skipped by the dispatcher (several with genuinely pending work at current skill SHAs). The symlinks bridge the naming without touching the dispatcher script or the eval files.

### Notes for reviewers

- Eval `github-issue-124` is malformed (its `prompt` and `assertions` are dangling paths to `admiral-adsl/benchmarks/basic-two-arm/`, which doesn't exist) and should be re-synced via `issue-to-eval`. Issues 36–40 also have backtick-wrapped `target_skills` values the dispatcher can't resolve, and issue 128 targets a nonexistent `r2rtf` skill — the symlinks don't cover those.

https://claude.ai/code/session_01RBC7VvAEZcabSdG8vMbHmm

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBC7VvAEZcabSdG8vMbHmm)_