### PR TITLE
issue-to-eval: import benchmark eval #159 and fix backtick skill names

### DIFF
--- a/_automation/evals/github-issue-159.json
+++ b/_automation/evals/github-issue-159.json
@@ -1,0 +1,30 @@
+{
+  "id": "github-issue-159",
+  "prompt": "Derive the AE (Adverse Events) SDTM domain from `pharmaverseraw::ae_raw` using `{sdtm.oak}`. The target output should match `pharmaversesdtm::ae`.\n\nThe raw AE dataset uses `PATNUM` as the subject identifier and `IT.*`-prefixed variable names reflecting a non-CDASH EDC format. Load the study CT spec with:\n\n```r\nct_spec <- read_ct_spec(ct_spec_example(\"ct-01-cm\"))\n```\n\n(Use as a proxy; in practice the study CT spec would be provided.)\n\nDerive the following variables using the appropriate sdtm.oak algorithms:\n\n- **Direct mappings (`assign_no_ct`):** `AETERM`, `AEDECOD`, `AEBODSYS`, `AELLT`, `AELLTCD`, `AEHLT`, `AEHLTCD`, `AEHLGT`, `AEHLGTCD`, `AESOC`, `AESOCCD`, `AEBDSYCD`\n- **Controlled terminology mappings (`assign_ct`):** `AESEV`, `AESER`, `AEREL`, `AEOUT`, `AEACN`, `AESDTH`, `AESCONG`, `AESDISAB`, `AESHOSP`, `AESLIFE`, `AESMIE`\n- **Datetime variables (`assign_datetime`):** `AESTDTC` from the raw AE start date variable; `AEENDTC` from the raw AE end date variable\n- **Hardcoded:** `DOMAIN = \"AE\"` using `hardcode_ct()` (validated against the DOMAIN codelist)\n\nDerive `AESTDY` and `AEENDY` using `derive_study_day()` with reference date from `pharmaverseraw::dm_raw`. Derive `AESEQ` as the sequence number within subject.",
+  "expected_output": "A single R script (`ae.R`) that produces the AE SDTM dataset comparable to `pharmaversesdtm::ae`.",
+  "files": [
+    "Use only CRAN-available packages:",
+    "`pharmaverseraw::ae_raw` \u2014 raw adverse events",
+    "`pharmaverseraw::dm_raw` \u2014 raw demographics (reference start date for study day)",
+    "`pharmaversesdtm::ae` \u2014 reference output for comparison",
+    "`read_ct_spec(ct_spec_example(\"ct-01-cm\"))` \u2014 example CT spec (proxy)"
+  ],
+  "assertions": [
+    "1. `generate_oak_id_vars()` is called on `ae_raw` with `pat_var = \"PATNUM\"` and `raw_src = \"ae_raw\"` before any derivation steps.",
+    "2. The CT spec is loaded with `read_ct_spec()` and validated with `assert_ct_spec()` before first use.",
+    "3. All direct-mapped variables are derived using `assign_no_ct()`, not `dplyr::mutate()` or `dplyr::rename()`.",
+    "4. All CT-mapped variables are derived using `assign_ct()` with both a `ct_spec` argument and a `ct_clst` argument; none are derived using `dplyr::mutate()` with `ct_map()` inline or any other workaround.",
+    "5. `DOMAIN` is hardcoded as `\"AE\"` using `hardcode_ct()` (not `hardcode_no_ct()`).",
+    "6. `AESTDTC` and `AEENDTC` are derived using `assign_datetime()` with an explicit `raw_fmt` argument; each `raw_fmt` value has a `# REVIEW:` annotation.",
+    "7. Every `ct_clst` value in an `assign_ct()` call has a `# REVIEW:` annotation marking it as protocol-specific.",
+    "8. `AESTDY` and `AEENDY` are derived using `derive_study_day()` with reference date joined from `dm_raw`; CDISC day 1 convention is correctly applied (no day 0).",
+    "9. `AESEQ` is derived using `derive_seq()`, not `row_number()` or manual sequencing.",
+    "10. The output `AE` dataset contains at minimum: `STUDYID`, `DOMAIN`, `USUBJID`, `AESEQ`, `AETERM`, `AEDECOD`, `AEBODSYS`, `AESEV`, `AESER`, `AESTDTC`, `AEENDTC`, `AESTDY`, `AEENDY`, `AEOUT`.",
+    "11. `nrow(ae)` matches `nrow(pharmaversesdtm::ae)` (record count agrees with the reference output).",
+    "12. `AETERM`, `AEDECOD`, `AESTDTC`, and `AESTDY` values agree with `pharmaversesdtm::ae` on matched records."
+  ],
+  "language": "R",
+  "target_skills": [
+    "sdtm-oak"
+  ]
+}

--- a/_automation/evals/github-issue-36.json
+++ b/_automation/evals/github-issue-36.json
@@ -14,6 +14,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "`group-sequential-design`"
+    "group-sequential-design"
   ]
 }

--- a/_automation/evals/github-issue-37.json
+++ b/_automation/evals/github-issue-37.json
@@ -15,6 +15,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "`group-sequential-design`"
+    "group-sequential-design"
   ]
 }

--- a/_automation/evals/github-issue-38.json
+++ b/_automation/evals/github-issue-38.json
@@ -14,6 +14,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "`group-sequential-design`"
+    "group-sequential-design"
   ]
 }

--- a/_automation/evals/github-issue-39.json
+++ b/_automation/evals/github-issue-39.json
@@ -15,6 +15,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "`group-sequential-design`"
+    "group-sequential-design"
   ]
 }

--- a/_automation/evals/github-issue-40.json
+++ b/_automation/evals/github-issue-40.json
@@ -15,6 +15,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "`group-sequential-design`"
+    "group-sequential-design"
   ]
 }

--- a/_automation/issue-to-eval/scripts/import_issue_eval.py
+++ b/_automation/issue-to-eval/scripts/import_issue_eval.py
@@ -27,7 +27,10 @@ def clean_value(val: str) -> str:
 
 
 def normalize_skill_name(name: str) -> str:
-    return clean_value(name).lower().replace(" ", "-").replace("_", "-")
+    # Strip backticks too — issue authors sometimes wrap the skill name in
+    # markdown code formatting (e.g. `sdtm-oak`), and backticks are never
+    # valid in a skill directory name.
+    return clean_value(name).lower().replace(" ", "-").replace("_", "-").replace("`", "")
 
 
 def parse_list_items(content: str, split_commas: bool = False) -> list[str]:


### PR DESCRIPTION
## Summary

Ran the `issue-to-eval` skill against the 35 GitHub issues labeled `benchmark`. One new eval was produced, five pre-existing evals were repaired, and a parsing fix was added to `import_issue_eval.py`.

### Issues imported (new)

| Issue | Skill | Title |
|---|---|---|
| #159 | sdtm-oak | AE domain derivation from pharmaverseraw source data |

### Evals repaired (backtick fix)

Five existing evals had `target_skills` stored with literal backticks (`` `group-sequential-design` ``), because the issue authors wrapped the skill name in markdown code formatting and `normalize_skill_name` did not strip backticks. The benchmark runner resolves the skill directory as `REPO_ROOT / target_skills[0]`, so a backtick-wrapped name never resolves and the eval is silently dropped. Fixed to the bare name:

- #36, #37, #38, #39, #40 → `group-sequential-design`

The same fix is what keeps the new #159 eval clean (its issue body declares the skill as `` `sdtm-oak` ``).

### Skipped / no change

- **#108** skipped — template placeholder with empty Skills/Query sections.
- All other parseable benchmark issues compared equal to the on-disk evals (after `html.unescape` normalization) and were left untouched.

## Code change

`_automation/issue-to-eval/scripts/import_issue_eval.py` — `normalize_skill_name` now also strips backticks, since backticks are never valid in a skill directory name. This prevents the broken `target_skills` from recurring on every future sync.

## Notes

- The `gh` CLI is unavailable in this environment, so the sync was run by feeding GitHub MCP issue bodies through `parse_issue_markdown` + `save_to_evals` directly, with `html.unescape` applied to bodies (the MCP returns HTML-encoded text) to stay byte-identical with prior `gh`-based runs.

## Test plan

- [ ] `_automation/evals/github-issue-159.json` carries `target_skills: ["sdtm-oak"]`, `language: "R"`, and 12 rubric assertions.
- [ ] `_automation/evals/github-issue-36..40.json` carry `target_skills: ["group-sequential-design"]` (no backticks).
- [ ] Re-running the sync reports every parseable issue as **Skipped** (up to date).

https://claude.ai/code/session_01Ab8kzTh2jfXsRnd6S4Vc7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab8kzTh2jfXsRnd6S4Vc7W)_