### PR TITLE
Fix get_next_eval.py emitting a STATUS line after the eval JSON

### DIFF
--- a/_automation/benchmark-runner/SKILL.md
+++ b/_automation/benchmark-runner/SKILL.md
@@ -269,10 +269,13 @@ state = json.loads(m.group(1))
 Also reload the full eval case (for assertions, scoring prompt, prompt_b):
 
 ```bash
+# Send stdout (the eval-case JSON) to the file and stderr (warnings such as
+# the >100 KB bundle notice) to a separate log. Do NOT use `2>&1` here — it
+# would merge warning lines into the JSON file and break the json.load below.
 python3 _automation/benchmark-runner/scripts/get_next_eval.py \
   --model {state["model"]} \
   --priority-issue {state["eval_id"]} \
-  > /tmp/eval_case_{id}.json 2>&1
+  > /tmp/eval_case_{id}.json 2>/tmp/eval_case_{id}.log
 ```
 
 Restore Agent A's output. If `agent_a_asset_url` is set, download and unzip it. Use whichever method works:

--- a/_automation/benchmark-runner/scripts/get_next_eval.py
+++ b/_automation/benchmark-runner/scripts/get_next_eval.py
@@ -658,9 +658,11 @@ def main() -> None:
     selected_eval["_selection_salt"] = selection_salt
 
     write_run_manifest(selected_eval, args.model, selected_eval["_skill_sha"], "dispatched")
+    # On success, stdout is the eval-case JSON and nothing else, so callers can
+    # parse it directly (see SKILL.md Step 1 / Step 5). The "STATUS: UP_TO_DATE"
+    # sentinel is reserved for the genuinely-nothing-to-run paths above; printing
+    # it here too would append a trailing non-JSON line and break json.load.
     print(json.dumps(selected_eval, indent=2))
-
-    print("STATUS: UP_TO_DATE")
 
 
 if __name__ == "__main__":

--- a/_automation/tests/test_benchmark_runner.py
+++ b/_automation/tests/test_benchmark_runner.py
@@ -345,5 +345,45 @@ class TestWriteRunManifest(unittest.TestCase):
                 gne.RUNS_DIR = original_runs_dir
 
 
+class TestMainStdoutContract(unittest.TestCase):
+    """main() must emit either a pure-JSON eval case OR a STATUS line — never both.
+
+    Regression guard for the bug where a stray `print("STATUS: UP_TO_DATE")`
+    followed the JSON dump, appending a trailing non-JSON line that broke
+    json.load for every downstream consumer (SKILL.md Step 1 / Step 5).
+    """
+
+    @patch("get_next_eval.write_run_manifest")
+    @patch("get_next_eval.fetch_and_check_comments")
+    def test_selected_eval_stdout_is_pure_json(self, mock_check, mock_manifest):
+        import io
+        import contextlib
+
+        # Pretend the eval has never been run so it is eligible.
+        mock_check.return_value = (False, 0, 0, "")
+
+        # Pick any real eval id present in _automation/evals/.
+        evals_dir = gne.REPO_ROOT / "_automation" / "evals"
+        eval_files = sorted(evals_dir.glob("*.json"))
+        self.assertTrue(eval_files, "no eval fixtures found to exercise main()")
+        eval_id = json.loads(eval_files[0].read_text(encoding="utf-8"))["id"]
+
+        argv = [
+            "get_next_eval.py",
+            "--model", "Claude Routine",
+            "--priority-issue", eval_id,
+        ]
+        buf = io.StringIO()
+        with patch.object(sys, "argv", argv), contextlib.redirect_stdout(buf):
+            gne.main()
+
+        stdout = buf.getvalue()
+        self.assertNotIn("STATUS:", stdout,
+                         "selected-eval stdout must not contain a STATUS sentinel line")
+        # The entire stdout must parse as a single JSON object.
+        parsed = json.loads(stdout)
+        self.assertEqual(parsed["id"], eval_id)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

When `get_next_eval.py` selects an eval, `main()` prints the eval-case JSON to stdout and then **also** prints `STATUS: UP_TO_DATE`:

```python
print(json.dumps(selected_eval, indent=2))
print("STATUS: UP_TO_DATE")   # ← stray trailing non-JSON line
```

Every downstream consumer parses this stdout as JSON — see `benchmark-runner/SKILL.md` Step 1 ("JSON output → parse to a temp file") and Step 5 (`get_next_eval.py ... > /tmp/eval_case_{id}.json`). The trailing line breaks `json.load` with:

```
json.decoder.JSONDecodeError: Extra data: line 48 column 1
```

It's also semantically contradictory: `STATUS: UP_TO_DATE` is meant to signal "nothing to run", yet here it's printed immediately after emitting a selected eval. This surfaced during a live benchmark run, where the routine had to special-case stripping the trailing line before it could parse the eval.

## Fix

Remove the stray `print` on the success path. On success, stdout is now pure eval-case JSON and nothing else, matching the documented contract. The `STATUS: UP_TO_DATE` sentinel is left intact on the two genuinely-nothing-to-run paths (no evals directory / no eligible evals).

## Test

Adds `TestMainStdoutContract.test_selected_eval_stdout_is_pure_json`, which runs `main()` against a real eval fixture (GitHub access mocked) and asserts the stdout parses as a single JSON object and contains no `STATUS:` line. Full suite: **28 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ESV5NQoPwZjC8fKPZGH5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_012ESV5NQoPwZjC8fKPZGH5Y)_