### PR TITLE
clinical-trial-simulation: crossover/treatment switching support (v0.2.17–v0.2.19)

### DIFF
--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,8 +6,8 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.17
-  trialsimulator_min_version: "1.18.4"
+  version: 0.2.18
+  trialsimulator_min_version: "1.20.1"
 ---
 
 # TrialSimulator Skill
@@ -210,7 +210,9 @@ calls for that kind of operation.
   `$remove_arms(arms_name)`, `$update_sample_ratio(arm_names, sample_ratios)`,
   `$update_generator(arm_name, endpoint_name, generator, ...)`,
   `$add_arms(sample_ratio, ...)` (mid-trial; same method as setup, used
-  for adaptive arm addition like dose-ranging, basket, or platform designs)
+  for adaptive arm addition like dose-ranging, basket, or platform designs),
+  `$crossover(what, how, when, delay)` (milestone-triggered treatment
+  crossover for patients still in the trial)
 - *Combination test in actions, for seamless / dose-selection designs*:
   `$dunnettTest(formula, placebo, treatments, milestones, alternative,
   planned_info, ...)`, `$closedTest(dunnett_test, treatments, milestones,
@@ -512,6 +514,55 @@ If none of these fit the user's design, ask for more details and
 implement a custom procedure (weighted Hochberg, parallel
 gatekeeping with logical restrictions, complex multi-population
 designs, etc.).
+
+## Crossover and treatment switching
+
+When patients receive, during the trial, a treatment other than the one
+assigned at randomization — crossover, treatment switching, rescue
+therapy, dose changes, and the like — these three vignettes cover three
+*distinct* switching designs, and which one applies is rarely clear until
+you have read them. Read all three in full before implementing, then pick
+the one that matches the user's design and follow it — do not improvise
+from a partial or approximate match:
+
+- **Washout crossover** — the classical within-patient crossover design
+  (e.g. 2×2 AB/BA or higher-order / multi-period), where each patient
+  receives treatments sequentially as their own control, separated by
+  untreated wash-out periods. The solution here is not the switching
+  machinery but an endpoint generator that simulates the outcome
+  accounting for the changing treatment over time.
+  https://zhangh12.github.io/TrialSimulator/articles/crossoverWashout.html
+- **Dynamic treatment switching** — per-patient switching driven by each
+  patient's own evolving outcome, available any time from randomization
+  onward (e.g. switch at progression, rescue after non-response, dose
+  changes, and other outcome-driven changes).
+  https://zhangh12.github.io/TrialSimulator/articles/dynamicTreatmentSwitching.html
+- **Crossover at a milestone** — crossover anchored to a trial-level time:
+  a fixed calendar time, or a milestone trigger not known until it fires
+  (e.g. an interim efficacy signal opens crossover for control patients
+  still on study).
+  https://zhangh12.github.io/TrialSimulator/articles/crossoverAtMilestone.html
+
+If none of the three covers the user's design, do not invent a workaround.
+That almost certainly means TrialSimulator cannot model the design — a rare
+and strong claim. Before making it, both re-read the vignettes carefully
+*and* confirm the design with the user — especially the specific aspects
+that appear to block TrialSimulator, since the mismatch may rest on a
+misunderstanding of what they need. Only after that, tell the user and stop.
+
+For the latter two, read the relevant function signatures if the vignette
+leaves any argument unclear.
+
+**Confirm the post-switch outcome model before implementing.** How each
+endpoint is generated or updated once treatment changes — the `how` step
+for switching / `crossover()`, or the generator logic for washout
+crossover — is a substantive modeling assumption that materially drives
+results (e.g. does a switch extend only residual survival, apply a hazard
+ratio, reset the hazard, or add benefit only after the switch?). Unless
+the user has specified this crystal-clearly, do not choose it yourself.
+When the model is non-trivial, write it up as a short supplement and
+**render it** (properly typeset math, not raw LaTeX in the chat) for the
+user to review and confirm before you implement it.
 
 ## Error-handling stance
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.18
+  version: 0.2.19
   trialsimulator_min_version: "1.20.1"
 ---
 

--- a/clinical-trial-simulation/SKILL.md
+++ b/clinical-trial-simulation/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pairs each block of code with rationale, parameters, and
   operating characteristics.
 metadata:
-  version: 0.2.16
+  version: 0.2.17
   trialsimulator_min_version: "1.18.4"
 ---
 

--- a/clinical-trial-simulation/references/building_blocks.md
+++ b/clinical-trial-simulation/references/building_blocks.md
@@ -437,11 +437,15 @@ regimen(what, when, how)
 
 | Arg | Type | Notes |
 |-----|------|-------|
-| `what` | function(patient_data) | Returns data.frame(patient_id, new_treatment); NA rows = skip patient |
-| `when` | function(patient_data) | Returns data.frame(patient_id, switch_time); no NAs allowed |
-| `how` | function(patient_data) | Returns modified columns + patient_id; NA = unchanged |
+| `what` | function(patient_data) | Returns data.frame(patient_id, new_treatment) — one row per switching patient; omit non-switchers |
+| `when` | function(patient_data) | Returns data.frame(patient_id, switch_time) for every switcher |
+| `how` | function(patient_data) | Returns patient_id + only the endpoint columns it changes; flip just the cells that change via `ifelse(cond, new, original)` |
 
 All three can be lists of functions executed sequentially.
+
+**Rules:**
+- `how()` may modify **post-switch outcomes only**. Returning a changed value for an endpoint whose event/readout is at or before `switch_time` errors. Guard it: `os = ifelse(os > switch_time, new_os, os)`.
+- Never apply dropout or censoring inside `how()` — TrialSimulator re-applies both automatically after the switch.
 
 ```r
 reg <- regimen(what = fn_who_switches, when = fn_when_to_switch, how = fn_update_data)

--- a/clinical-trial-simulation/references/building_blocks.md
+++ b/clinical-trial-simulation/references/building_blocks.md
@@ -9,8 +9,8 @@ endpoint(name, type, readout = NULL, generator, ...)
 | Arg | Type | Required | Notes |
 |-----|------|----------|-------|
 | `name` | character vector | yes | One or more endpoint names; must match generator output column names exactly |
-| `type` | character vector | yes | `"tte"` or `"non-tte"` per name |
-| `readout` | named numeric vector | if non-tte | `c(ep_name = time_value)`; omit or NULL if all TTE |
+| `type` | character vector | yes | `"tte"`, `"non-tte"`, or `"baseline"` per name; use `"baseline"` for a non-tte variable observed at randomization |
+| `readout` | named numeric vector | if non-tte | `c(ep_name = time_value)` per non-tte name; omit/NULL for tte and baseline names (a `"baseline"` endpoint's readout is 0 by definition and must not appear here) |
 | `generator` | function(n, ...) | yes | First argument must be `n`; returns data.frame with one row per patient |
 | `...` | named values | no | Passed to `generator` at call time |
 
@@ -20,7 +20,7 @@ endpoint(name, type, readout = NULL, generator, ...)
 - Custom TTE generators must include a `<name>_event` column (1 = event, 0 = censored). Built-in generators (e.g., `rexp`, `PiecewiseConstantExponentialRNG`) handle this automatically for a single TTE endpoint.
 - Any function whose first argument is not `n` must be wrapped before passing as `generator` (e.g., `sample()` must be wrapped; `rbinom`, `rnorm` do not).
 - `...` can be used to share one generator across arms with different parameter values (e.g., `hr = 0.7`); arms can also use completely independent generators — both are valid.
-- All patient-level variables — endpoints, covariates, biomarkers, subgroup flags — must go through `endpoint()`. Baseline variables use `readout = 0` and `type = "non-tte"`; pass their names to `stratification_factors` in `trial()` for stratified randomization.
+- All patient-level variables — endpoints, covariates, biomarkers, subgroup flags — must go through `endpoint()`. Baseline variables use `type = "baseline"`; pass their names to `stratification_factors` in `trial()` for stratified randomization.
 - Multiple endpoints/variables can be defined in a single `endpoint()` call or across multiple calls — choose based on readability. A single call with a combined generator is convenient when many endpoints share one generator. Separate calls (e.g., `ep1 = endpoint(..., generator = rexp); ep2 = endpoint(..., generator = rnorm)`) are often cleaner when each endpoint has its own simple generator. Pass all resulting objects to `arm$add_endpoints(ep1, ep2, ...)`.
 - Repeated measurements of one endpoint: define each visit as a separate name in `name`, with its assessment time in `readout`. The generator returns all visits jointly (one column per visit), allowing correlation across time.
 
@@ -38,7 +38,7 @@ endpoint(name, type, readout = NULL, generator, ...)
 | — TTE marginal + NORTA, piecewise exponential | Must use built-in `qPiecewiseExponential(p, times, piecewise_risk)`; other distributions use standard quantile functions (e.g., `qexp`, `qweibull`) |
 | — NORTA correlation feasibility | Target correlation in `cor_target_final` may not be achievable for all marginal combinations (e.g., binary variables have bounded correlation range); `simdesign_norta()` will error if infeasible — inform the user and ask to adjust |
 | Repeated measures of one endpoint | Custom function returning one column per visit |
-| Baseline variable (covariate, biomarker, subgroup) | Custom function with `readout = 0`; wrap if first argument is not `n` |
+| Baseline variable (covariate, biomarker, subgroup) | Custom function with `type = "baseline"`; wrap if first argument is not `n` |
 
 **Examples:**
 
@@ -144,8 +144,7 @@ ep_exp   <- endpoint(name = "response", type = "non-tte",
 
 # Baseline variable — wrap if first argument is not n (e.g., sample())
 gen_stage <- function(n, ...) { ... }  # returns: data.frame(stage)
-ep_stage  <- endpoint(name = "stage", type = "non-tte",
-                      readout = c(stage = 0), generator = gen_stage)
+ep_stage  <- endpoint(name = "stage", type = "baseline", generator = gen_stage)
 
 # --- Repeated measures ---
 
@@ -203,8 +202,8 @@ gen_norta <- function(n, ...) {
 
 ep <- endpoint(
   name      = c("os", "secondary", "baseline_bin", "baseline_unif"),
-  type      = c("tte", "non-tte", "non-tte", "non-tte"),
-  readout   = c(secondary = 10, baseline_bin = 0, baseline_unif = 0),
+  type      = c("tte", "non-tte", "baseline", "baseline"),
+  readout   = c(secondary = 10),
   generator = gen_norta
 )
 
@@ -214,15 +213,14 @@ ep <- endpoint(
 ep_os       <- endpoint(name = "os",       type = "tte",     generator = rexp, rate = log(2) / 12)
 ep_response <- endpoint(name = "response", type = "non-tte", readout = c(response = 8),
                         generator = rbinom, size = 1, prob = 0.4)
-ep_baseline <- endpoint(name = "stage",    type = "non-tte", readout = c(stage = 0),
-                        generator = gen_stage)
+ep_baseline <- endpoint(name = "stage",    type = "baseline", generator = gen_stage)
 ctrl$add_endpoints(ep_os, ep_response, ep_baseline)
 
 # Single call: convenient when many endpoints share one combined generator
 ep_all <- endpoint(
   name      = c("os", "response", "stage"),
-  type      = c("tte", "non-tte", "non-tte"),
-  readout   = c(response = 8, stage = 0),
+  type      = c("tte", "non-tte", "baseline"),
+  readout   = c(response = 8),
   generator = gen_all  # returns: data.frame(os, os_event, response, stage)
 )
 ctrl$add_endpoints(ep_all)
@@ -270,7 +268,7 @@ trial(name, n_patients, duration, description = name, seed = NULL,
 | `seed` | numeric/NULL | no | NULL = auto per-replicate |
 | `enroller` | function | yes | **Always `StaggeredRecruiter`** — the only enroller this skill supports. Never a custom function or any other value. |
 | `dropout` | function | no | Returns dropout time vector of length n. **One global dropout function per trial — applies to ALL endpoints uniformly per patient.** Each patient draws a single dropout time; that time censors every TTE endpoint and zeroes out any non-TTE readouts whose readout-time exceeds it. There is no API for endpoint-specific dropout. See helpers.md "Global dropout — no per-endpoint variation". |
-| `stratification_factors` | character | no | Names of baseline endpoints (`readout = 0`); enables stratified randomization |
+| `stratification_factors` | character | no | Names of baseline endpoints (`type = "baseline"`); enables stratified randomization |
 | `silent` | logical | no | Suppress messages |
 | `...` | any | no | Passed to `enroller` and `dropout` |
 

--- a/clinical-trial-simulation/references/building_blocks.md
+++ b/clinical-trial-simulation/references/building_blocks.md
@@ -268,7 +268,7 @@ trial(name, n_patients, duration, description = name, seed = NULL,
 | `n_patients` | integer | yes | Initial max enrollment; adjustable via `$resize()` |
 | `duration` | numeric | yes | Trial timeframe; adjustable via `$set_duration()` |
 | `seed` | numeric/NULL | no | NULL = auto per-replicate |
-| `enroller` | function | yes | Returns enrollment time vector of length n; see built-in `StaggeredRecruiter` |
+| `enroller` | function | yes | **Always `StaggeredRecruiter`** — the only enroller this skill supports. Never a custom function or any other value. |
 | `dropout` | function | no | Returns dropout time vector of length n. **One global dropout function per trial — applies to ALL endpoints uniformly per patient.** Each patient draws a single dropout time; that time censors every TTE endpoint and zeroes out any non-TTE readouts whose readout-time exceeds it. There is no API for endpoint-specific dropout. See helpers.md "Global dropout — no per-endpoint variation". |
 | `stratification_factors` | character | no | Names of baseline endpoints (`readout = 0`); enables stratified randomization |
 | `silent` | logical | no | Suppress messages |
@@ -277,7 +277,7 @@ trial(name, n_patients, duration, description = name, seed = NULL,
 **Rules:**
 - Units of `duration`, `dropout`, and non-tte `readout` must be consistent.
 - Baseline covariates are assumed to have the same distribution across arms.
-- `StaggeredRecruiter(n, accrual_rate)` is the standard built-in enroller. `accrual_rate` is a data.frame with columns `end_time` and `piecewise_rate`; pass it via `...`.
+- **`trial()` MUST set `enroller = StaggeredRecruiter` and MUST also supply `accrual_rate`** (passed via `...`). `accrual_rate` is a data.frame with columns `end_time` and `piecewise_rate`. The two go together — `StaggeredRecruiter` is non-functional without `accrual_rate`.
 
 **Example:**
 ```r

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -269,7 +269,14 @@ example than from prose.
 
 | Function | Purpose |
 |---|---|
-| `expandRegimen(data)` | Expand the compact `regimen_trajectory` column in locked data into one row per regimen segment per patient (adds `regimen` and `switch_time_from_enrollment`; drops `regimen_trajectory`). Use **inside an action function** — typically right after `trial$get_locked_data(...)` — to make a switching trajectory readable for downstream computation. Only meaningful when treatment switching is enabled via `add_regimen`. |
+| `expandRegimen(data)` | Expand the compact `regimen_trajectory` column in locked data into one row per regimen segment per patient (adds `regimen` and `switch_time_from_enrollment`; drops `regimen_trajectory`). Use **inside an action function** — typically right after `trial$get_locked_data(...)` — to make a switching trajectory readable for downstream computation. Only meaningful when treatment switching is enabled via `add_regimen` or `crossover()`. |
+
+Locked data also carries an `n_switches` column — the per-patient count of
+treatment switches within the lock window. Use it directly for crossover /
+switch-rate operating characteristics and QC (e.g. fraction who switched,
+fraction switching more than once), rather than recomputing from
+`regimen_trajectory`. Meaningful only when switching is enabled
+(`add_regimen` or `crossover()`).
 
 ## Post-simulation utilities
 

--- a/clinical-trial-simulation/references/helpers.md
+++ b/clinical-trial-simulation/references/helpers.md
@@ -16,7 +16,10 @@ https://zhangh12.github.io/TrialSimulator/reference/.
 
 ## Enroller
 
-`StaggeredRecruiter` is the only enroller this skill uses. It is **for
+`trial()` **MUST always** set `enroller = StaggeredRecruiter` — it is the
+only enroller this skill supports; never a custom function. Setting it
+**requires** passing `accrual_rate` (via `trial(..., accrual_rate = <data.frame>)`);
+the two are inseparable. `StaggeredRecruiter` is **for
 `trial(enroller = ...)` only — never as an `endpoint(generator = ...)`**.
 
 | Function | Purpose |


### PR DESCRIPTION
Builds out treatment-switching / crossover support in the `clinical-trial-simulation` skill, aligned with upstream TrialSimulator 1.20.0, plus two related cleanups.

## v0.2.17 — enroller
- Force `enroller = StaggeredRecruiter` in `trial()` (the only supported enroller) and require `accrual_rate` alongside it. Updates the arg table, `trial()` rules, and the Enroller section from descriptive convention to hard MUST rules.

## v0.2.18 — crossover / treatment switching
- Register `trial$crossover()` in the sanctioned adaptive-methods list (treated like any other `trial$*()` adaptation).
- New **Crossover and treatment switching** section in `SKILL.md`: routes the agent to the three upstream vignettes (washout / dynamic switching / crossover-at-milestone) — read all three, pick the match, do not improvise. If none fits, re-read **and** confirm the design with the user before concluding TrialSimulator cannot model it, then stop.
- Force confirmation of the **post-switch outcome model** before implementing, with a rendered-supplement (typeset math) option.
- Refresh the `regimen()` triplet contract (return only switchers; `ifelse(cond, new, original)` in `how()`; post-switch-only modification rule).
- Bump `trialsimulator_min_version` 1.18.4 → 1.20.1.

## v0.2.19 — baseline endpoint type + n_switches
- Adopt `endpoint(type = "baseline")` for non-tte variables observed at randomization; retire `readout = 0` except the longitudinal repeated-measures idiom.
- Document the `n_switches` locked-data column for crossover / switch-rate operating characteristics and QC, alongside `expandRegimen`; note `crossover()` (not only `add_regimen`) as a switching enabler.

## Notes
- `SKILL.html` is regenerated locally for review but is gitignored, so it is not part of these commits.
- Deferred (not in this PR): `Surv()/strata()` re-export note, `options(trialsimulator.use_cpp = FALSE)` flag.