### PR TITLE
fix: implement PPROTFL derivation in admiral-adsl SKILL.md (was dead commented code)

### DIFF
--- a/admiral/admiral-adsl/SKILL.md
+++ b/admiral/admiral-adsl/SKILL.md
@@ -380,20 +380,20 @@ if (!exists("dv")) {
 
 dv_major <- dv |>
   select(-DOMAIN) |>
-  mutate(MAJORDVFL = "Y")
+  mutate(MAJDVFL = "Y")
 
 adsl <- adsl |>
   derive_vars_merged(
     dataset_add = dv_major,
     by_vars     = exprs(STUDYID, USUBJID),
-    new_vars    = exprs(MAJORDVFL),
+    new_vars    = exprs(MAJDVFL),
     filter_add  = DVCAT == "MAJOR",
     mode        = "first"   # subjects may have >1 major deviation record; any match suffices
   ) |>
   mutate(
-    PPROTFL = if_else(ITTFL == "Y" & is.na(MAJORDVFL), "Y", NA_character_)
+    PPROTFL = if_else(ITTFL == "Y" & is.na(MAJDVFL), "Y", NA_character_)
   ) |>
-  select(-MAJORDVFL)  # intermediate exclusion flag; not an ADSL output variable
+  select(-MAJDVFL)  # intermediate exclusion flag; not an ADSL output variable
 ```
 
 ### Step 12 — Dataset attributes and final checks

--- a/admiral/admiral-adsl/SKILL.md
+++ b/admiral/admiral-adsl/SKILL.md
@@ -43,6 +43,7 @@ as absent:
 | DM | Yes | Subject spine; one record per USUBJID |
 | EX | Yes | Exposure; needed for treatment dates and SAFFL |
 | DS | Yes | Disposition; needed for EOSSTT, DCSREAS |
+| DV | No | Protocol deviations; needed for PPROTFL |
 | MH | No | Medical history flags if protocol requires |
 | VS | No | HEIGHTBL, WEIGHTBL, BMIBL if in scope |
 | ADaM ADSL spec | Yes | Variable list, derivation rules, grouping cut-points |
@@ -356,9 +357,43 @@ adsl <- adsl |>
       NA_character_
     )
   )
-  # PPROTFL: per protocol — highly protocol-specific
-  # REVIEW: Derive per SAP definition with protocol deviation exclusions.
-  # mutate(PPROTFL = if_else(ITTFL == "Y" & no_major_deviations, "Y", NA_character_))
+# ITTFL pipe chain ends here; PPROTFL is derived separately below.
+
+# PPROTFL: per-protocol — ITT subjects with no major protocol deviations.
+# Uses derive_vars_merged() + filter_add (not derive_var_merged_exist_flag) because
+# the exclusion criterion belongs in filter_add, and NA absence of a match is the
+# natural signal that no major deviation record was found for the subject.
+#
+# Guard: DV-absent and DV-present-but-no-major-deviations are different states
+# and must not produce the same PPROTFL output. If DV is not loaded, halt so the
+# analyst can decide explicitly — do not silently set NA.
+# REVIEW: DVCAT values must match the protocol deviation management plan (PDMP).
+#   Some studies categorise by DVCAT == "MAJOR"; others use DVSCAT or a study-
+#   specific flag. Confirm the filter_add condition with the statistician before use.
+if (!exists("dv")) {
+  stop(
+    "DV domain is required for PPROTFL derivation but is not loaded. ",
+    "Load DV, or set adsl$PPROTFL <- NA_character_ explicitly if the study ",
+    "has no protocol deviation records and this has been confirmed with the statistician."
+  )
+}
+
+dv_major <- dv |>
+  select(-DOMAIN) |>
+  mutate(MAJORDVFL = "Y")
+
+adsl <- adsl |>
+  derive_vars_merged(
+    dataset_add = dv_major,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_vars    = exprs(MAJORDVFL),
+    filter_add  = DVCAT == "MAJOR",
+    mode        = "first"   # subjects may have >1 major deviation record; any match suffices
+  ) |>
+  mutate(
+    PPROTFL = if_else(ITTFL == "Y" & is.na(MAJORDVFL), "Y", NA_character_)
+  ) |>
+  select(-MAJORDVFL)  # intermediate exclusion flag; not an ADSL output variable
 ```
 
 ### Step 12 — Dataset attributes and final checks


### PR DESCRIPTION
## Summary

Benchmark #165 (admiral-adsl ADSL safety flag derivation) scored 82.6% with skill vs 45.7% without — but both agents independently failed the same assertion: PPROTFL derivation does not use derive_vars_merged() with filter_add.

Root cause, confirmed by reading the skill source directly: the SKILL.md PPROTFL guidance was never implemented. It existed only as a commented-out stub referencing a placeholder variable (no_major_deviations) that was never connected to any real data source — unlike SAFFL, which has a fully working derive_var_merged_exist_flag() implementation directly above it in the same pipe chain.

## What changed

- Implemented PPROTFL using derive_vars_merged() + filter_add, not derive_var_merged_exist_flag(). SAFFL is correctly an inclusion-flag pattern (does a qualifying dose record exist?); PPROTFL is an exclusion-flag pattern (is the subject absent from major-deviation records?). Forcing the exist_flag function onto exclusion logic fights the natural read of the code and was the wrong function for this case.
- Added a stop() guard when the DV domain is not loaded, with an explicit message distinguishing two states that must not be conflated: "DV absent" (PPROTFL is genuinely underivable) vs. "DV present with zero major deviations" (PPROTFL should be "Y" for all ITT subjects). Silently defaulting to NA in both cases was the original stub's implicit behavior and would have hidden a real data gap.
- Added mode = "first" handling for subjects with multiple major-deviation records.
- Added # REVIEW: annotation flagging that DVCAT vs DVSCAT categorization varies by study and must be confirmed against the protocol deviation management plan (PDMP) before use — consistent with the annotation style already used for SAFFL's EXTRT/EXDOSE nuance.

## Evidence

Both Agent A (with skill) and Agent B (without skill) in benchmark #165 failed the PPROTFL derive_vars_merged() assertion identically. Reading the SKILL.md source confirms why: there was no implementation for either agent to follow — the guidance was dead code.

## Test plan

- [x] Re-run benchmark #165 and confirm the PPROTFL derive_vars_merged() assertion now passes for Agent A
- [x] Confirm no regression on SAFFL/ITTFL assertions
- [ ] Confirm the stop() guard fires correctly when DV is not loaded in a test scenario

cc @jeffreyad — flagging since you reviewed the #167 CBRESPFL discussion and the original #152 PARAMCD fix this follows the same pattern of.