### PR TITLE
feat: admiral-adrs skill — RECIST 1.1 tumor response derivation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ pharma_skills/
 │   ├── SKILL.md               ← Shared conventions (date rules, flags, QC)
 │   ├── admiral-adsl/          ← Subject-level dataset (ADSL)
 │   ├── admiral-bds/           ← BDS findings datasets (ADVS, ADLB)
-│   └── admiral-adae/          ← Adverse events dataset (ADAE)
+│   ├── admiral-adae/          ← Adverse events dataset (ADAE)
+│   └── admiral-adrs/          ← Tumor response dataset (ADRS, RECIST)
 ├── _automation/               ← Automation skills (see below)
 │   ├── benchmark-runner/      ← A/B benchmark orchestration
 │   ├── issue-to-eval/         ← GitHub Issue → evals.json converter
@@ -34,6 +35,7 @@ pharma_skills/
 | `admiral/admiral-adsl` | "derive ADSL", "create subject-level dataset", "admiral ADSL" |
 | `admiral/admiral-bds` | "derive ADVS", "derive ADLB", "vital signs dataset", "lab dataset", "BDS findings", "admiral BDS" |
 | `admiral/admiral-adae` | "derive ADAE", "adverse events dataset", "TEAE flag", "treatment-emergent", "admiral ADAE" |
+| `admiral/admiral-adrs` | "derive ADRS", "tumor response dataset", "RECIST", "confirmed ORR", "best overall response", "BOR", "clinical benefit", "admiralonco" |
 | `benchmark-runner` | "run benchmarks", "compare skill performance", "eval the skills" |
 | `benchmark-summary` | "update the benchmark summary", "generate benchmark analysis", "summarize skill vs no-skill results", "add failure patterns", produce `benchmark_analysis_*.md` |
 | `issue-to-eval` | "parse this issue into a benchmark", "sync all benchmark issues" |

--- a/admiral/SKILL.md
+++ b/admiral/SKILL.md
@@ -29,7 +29,8 @@ Choose the child skill that matches the target ADaM dataset type:
 |---|---|---|
 | ADSL — Subject-Level | `admiral/admiral-adsl` | Treatment dates, disposition, population flags |
 | BDS — Findings (ADVS, ADLB) | `admiral/admiral-bds` | Parameters, baseline, change from baseline |
-| OCCDS — Adverse Events | `admiral/admiral-adae` | *(planned)* |
+| OCCDS — Adverse Events | `admiral/admiral-adae` | TEAE flag, severity, seriousness, causality |
+| Tumor Response (ADRS) | `admiral/admiral-adrs` | RECIST response, confirmed ORR, BOR, clinical benefit |
 | TTE — Time to Event | `admiral/admiral-adtte` | *(planned)* |
 
 ADSL must be derived before any BDS or OCCDS dataset — population flags and

--- a/admiral/admiral-adrs/DESIGN.md
+++ b/admiral/admiral-adrs/DESIGN.md
@@ -1,0 +1,200 @@
+# DESIGN.md — admiral-adrs
+
+This document records the design decisions, scope boundaries, and open questions
+for the `admiral-adrs` skill.
+
+---
+
+## Skill Purpose
+
+Derive a CDISC-conformant ADaM Tumor Response Analysis Dataset (ADRS) using the
+{admiral} and {admiralonco} R packages. The skill encodes the workflow, function
+selection logic, and oncology-specific conventions an experienced admiralonco
+programmer applies — enabling an AI coding agent to generate QC-ready,
+audit-traceable R code from SDTM RS and a completed ADSL dataset.
+
+---
+
+## Scope
+
+### In scope
+
+- ADRS derivation for RECIST 1.1 oncology studies (investigator assessment)
+- Five standard ADRS parameters: OVRLRESP, RSP, CONFIRMED, BESTRESP, CBRESPFL
+- Date derivation (ADT, ADTF, ADY) from RSDTC using admiral functions
+- Confirmed response per RECIST 1.1 (CR/PR ≥28 days apart)
+- Best Overall Response with NE propagation via `derive_param_confirmed_bor()`
+- Clinical benefit (SD/PR/CR ≥42 days from reference date)
+- Verification: confirmed ORR ≤ unconfirmed ORR, PD-never-confirmed assertions
+- SDTM RS inputs following CDISC SDTMIG conventions
+- R implementation using admiral and admiralonco
+
+### Out of scope (initial release)
+
+- iRECIST response criteria
+- BICR (Blinded Independent Central Review) assessor — covered as a `# REVIEW:`
+  note in the PARAMCD filter, but not a separate workflow
+- RECIST 1.0, Cheson criteria, Lugano classification, irRC
+- SAS implementation
+- ADTTE derivation — planned as a separate `admiral-adtte` skill
+- Integrated tumor burden (sum of longest diameters) — requires raw measurement
+  data not captured in RSSTRESC
+- Non-pharmaverse R implementations
+
+---
+
+## Key Design Decisions
+
+### Decision 1: admiral-adrs as a separate skill rather than admiral-onco covering ADRS + ADTTE
+
+**Decision:** Build a focused `admiral-adrs` skill covering tumor response only,
+rather than a combined `admiral-onco` skill covering ADRS and ADTTE.
+
+**Rationale:**
+- ADTTE uses base `admiral` functions (`derive_param_tte()`, `event_source()`,
+  `censor_source()`), not `admiralonco` — the package dependency differs
+- ADTTE is not oncology-specific; it is used in cardiovascular, respiratory,
+  and other therapeutic areas with time-to-event endpoints
+- The parent `admiral/SKILL.md` routing table already plans a separate
+  `admiral-adtte` slot
+- Focused skills are more testable: each benchmark can be attributed to a
+  specific gap without cross-contamination from a different workflow
+
+**Alternative considered:** A single `admiral-onco` skill covering ADRS + ADTTE.
+Rejected because PFS ADTTE for oncology often derives event dates from ADRS
+milestone assessments, but the TTE derivation workflow itself belongs in
+`admiral-adtte`; the link between them is documented in the relationship table
+in README.md.
+
+**Status:** Decided.
+
+---
+
+### Decision 2: CONFIRMED and CBRESPFL as "Y"/"N" exceptions to the flag convention
+
+**Decision:** The skill explicitly documents that CONFIRMED and CBRESPFL use
+`"Y"`/`"N"` values, not `"Y"`/`NA`, and instructs the agent not to recode them.
+
+**Rationale:**
+- `derive_param_confirmed_resp()` and `derive_param_clinbenefit()` produce `"N"`
+  for subjects who were assessed but did not meet the response criterion. The
+  `"N"` is meaningful — it distinguishes "assessed, not confirmed" from "not yet
+  assessed" (which would appear as a missing record, not a `"N"` value).
+- Recoding `"N"` to `NA` breaks downstream `derive_param_confirmed_bor()`, which
+  uses the presence of explicit `"N"` CONFIRMED records to correctly handle the
+  BOR hierarchy for non-responding subjects.
+- This is a documented admiralonco contract, not a CDISC deviation.
+- The skill flags this prominently to prevent a common agent error: applying the
+  general `"Y"`/`NA` convention from the parent skill and breaking the pipeline.
+
+**Status:** Decided.
+
+---
+
+### Decision 3: RANDDT as the default clinical benefit reference date, with mandatory REVIEW annotation
+
+**Decision:** SKILL.md uses `RANDDT` as the placeholder for `reference_date` in
+`derive_param_clinbenefit()` but requires a `# REVIEW:` comment explaining the
+alternative (per-subject first-qualifying-assessment date).
+
+**Rationale:**
+- RANDDT is the conventional anchor in RECIST-based clinical benefit definitions
+  per most regulatory guidance, but the literal RECIST 1.1 wording ("≥42 days
+  from first SD/PR/CR assessment") implies a per-subject first-assessment anchor.
+- The #167 benchmark identified this as a real failure point: the unskilled agent
+  computed per-subject first-assessment dates (literal reading) while the skilled
+  agent used RANDDT (conventional reading) — both are defensible but they produce
+  different subject counts.
+- A `# REVIEW:` comment forces the programmer to resolve this before submission,
+  rather than silently accepting the default.
+
+**Status:** Decided.
+
+---
+
+### Decision 4: RSP parameter retained for ORR verification
+
+**Decision:** The skill derives an RSP (unconfirmed response) parameter and
+includes a mandatory `stopifnot(n_confirmed <= n_unconfirmed)` assertion.
+
+**Rationale:**
+- Confirmed ORR greater than unconfirmed ORR is logically impossible but has
+  occurred in practice when the confirmation window is mis-specified (e.g.,
+  `ref_confirm = 2` interpreted as 2 weeks instead of 2 days). The assertion
+  catches this silently.
+- The #167 benchmark penalised the skilled agent for not printing the confirmed
+  vs unconfirmed ORR comparison; the unskilled agent produced this output and
+  scored higher on that assertion. The skill now requires it explicitly.
+
+**Status:** Decided.
+
+---
+
+### Decision 5: pharmaversesdtm::rs_onco_recist as the test data object
+
+**Decision:** SKILL.md documents that the plain `rs` object is no longer
+exported from pharmaversesdtm and instructs the agent to use `rs_onco_recist`.
+
+**Rationale:**
+- Both agents in the #167 benchmark independently discovered this at runtime,
+  adding turns and token overhead. Encoding it in the skill avoids the discovery
+  cost on every run.
+- `rs_onco_recist` is the correct RECIST 1.1 oncology test dataset; it has 8
+  subjects and 66 records, sufficient for confirming the derivation pipeline.
+
+**Status:** Decided.
+
+---
+
+## Open Questions
+
+### OQ-1: BICR assessor as a first-class workflow step
+
+Should the skill include a Step 6b for BICR-assessed response parameters, or
+treat BICR as a `# REVIEW:` note within the filter condition?
+
+**Current inclination:** `# REVIEW:` note only for initial release — most
+oncology submissions use investigator assessment as primary, with BICR as a
+sensitivity analysis derived by the same code path with a different filter.
+
+---
+
+### OQ-2: ANL01FL for primary analysis population
+
+ADRS often includes an ANL01FL flag to mark records in the primary analysis
+population (e.g., subjects with ≥1 evaluable post-baseline assessment). Should
+the skill add a Step 11 for ANL01FL derivation?
+
+**Current inclination:** Yes for v0.2 — ANL01FL is protocol-specific and needs
+a `# REVIEW:` annotation, consistent with the pattern in admiral-bds.
+
+---
+
+### OQ-3: Benchmark for the RANDDT vs first-assessment anchor ambiguity
+
+Should there be a dedicated benchmark that tests whether the agent correctly
+identifies the clinical benefit anchor ambiguity and annotates it with
+`# REVIEW:`?
+
+**Current inclination:** Yes — this is the highest-risk silent failure in ADRS
+derivation and warrants a targeted eval case.
+
+---
+
+## Benchmarks
+
+Benchmarks are tracked as GitHub issues with the `benchmark` and `eval` labels at
+https://github.com/RConsortium/pharma-skills/issues.
+
+The existing #167 benchmark (`[benchmark][admiral-bds] ADRS derivation`) serves
+as the initial eval for this skill — the skill was not yet available when that
+benchmark ran. Re-running #167 against this skill will establish the baseline
+delta vs. the old admiral-bds routing.
+
+---
+
+## Revision History
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-08-13 | Jeff Dickinson | Initial draft — created from #167 benchmark failure analysis |

--- a/admiral/admiral-adrs/LICENSE
+++ b/admiral/admiral-adrs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jeff Dickinson, Navitas Data Sciences
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/admiral/admiral-adrs/README.md
+++ b/admiral/admiral-adrs/README.md
@@ -1,0 +1,117 @@
+# admiral-adrs
+
+An agent skill for deriving ADaM Tumor Response Analysis Datasets (ADRS) using
+the [{admiral}](https://pharmaverse.github.io/admiral/) and
+[{admiralonco}](https://pharmaverse.github.io/admiralonco/) R packages.
+
+## Overview
+
+ADRS is an ADaM dataset that contains tumor response assessments derived from
+SDTM RS domain data following RECIST criteria. It is the primary dataset for
+oncology efficacy analysis: overall response rate (ORR), confirmed ORR, best
+overall response (BOR), and clinical benefit rate (CBR).
+
+This skill encodes the workflow, function selection logic, and CDISC conventions
+that an experienced admiralonco programmer applies when building ADRS — enabling
+an AI coding agent to generate QC-ready, audit-traceable R code from SDTM RS
+and a completed ADSL dataset.
+
+## When to Use This Skill
+
+Use `admiral-adrs` when you need to:
+
+- Derive an ADRS dataset from SDTM RS using R, admiral, and admiralonco
+- Implement RECIST 1.1 confirmed response (CR/PR ≥28 days apart)
+- Derive Best Overall Response (BOR) with correct NE propagation and hierarchy
+- Derive clinical benefit (durable SD/PR/CR ≥42 days from a reference date)
+- Produce code structured for human QC review and regulatory submission
+- Verify confirmed ORR ≤ unconfirmed ORR with programmatic assertions
+
+## Inputs Required
+
+| Input | Required | Description |
+|---|---|---|
+| RS | Yes | One record per tumor assessment per subject (RSSTRESC: CR/PR/SD/PD/NE) |
+| ADSL | Yes | Provides TRTSDT, RANDDT, treatment labels, population flags |
+| ADaM ADRS spec | Yes | PARAMCD/PARAM mapping, confirmation window, clinical benefit definition |
+| Study context | Yes | RECIST version, assessor (investigator vs BICR), confirmation window, clinical benefit anchor |
+
+## Outputs
+
+- Executable R code using admiralonco functions following pharmaverse idioms
+- Five standard ADRS parameters: OVRLRESP, RSP, CONFIRMED, BESTRESP, CBRESPFL
+- `# REVIEW:` annotations at every protocol-specific decision point:
+  confirmation window (`ref_confirm`), NE handling (`missing_as_ne`), clinical
+  benefit anchor (`reference_date`, `ref_start_window`), PARAMCD/PARAM mapping
+- Programmatic verification: confirmed vs unconfirmed ORR comparison printed,
+  `stopifnot(confirmed_n <= unconfirmed_n)` assertion, PD-never-confirmed check
+- Structural assertions: required parameter coverage, uniqueness per subject ×
+  PARAMCD, required variable presence
+
+## Skill Files
+
+```
+admiral-adrs/
+├── SKILL.md          # Core agent instructions and workflow
+├── DESIGN.md         # Scope, constraints, design decisions
+├── README.md         # This file
+├── benchmarks/
+│   └── README.md     # Planned benchmark scenarios
+└── LICENSE
+```
+
+## Dependencies
+
+```r
+# Core
+library(admiral)        # >= 1.2.0
+library(admiralonco)    # >= 1.0.0
+library(dplyr)
+library(lubridate)
+
+# Test data
+library(pharmaversesdtm)  # rs_onco_recist for benchmark runs
+library(pharmaverseadam)  # reference ADaM outputs
+```
+
+## Key Gotchas
+
+**pharmaversesdtm:** The plain `rs` object is no longer exported. Use
+`rs_onco_recist` for test data.
+
+**Flag convention exception:** `CONFIRMED` and `CBRESPFL` use `"Y"`/`"N"`,
+not `"Y"`/`NA` — this is the admiralonco contract for these response-existence
+parameters. Do not recode.
+
+**DOMAIN removal timing:** Remove DOMAIN from RS in Step 2, before any
+`derive_param_*()` call, not in the final `select()`.
+
+## Benchmarks
+
+Benchmarks are tracked as GitHub issues with the `benchmark` and `eval` labels at
+https://github.com/RConsortium/pharma-skills/issues.
+
+## Relationship to Other Skills
+
+```
+admiral-adsl        ← subject-level foundation (must be derived first)
+admiral-adrs        ← this skill (tumor response, RECIST)
+admiral-adtte       ← time-to-event (PFS often uses ADRS milestone dates)
+admiral-adae        ← adverse events (OCCDS)
+admiral-bds         ← general BDS findings (ADVS, ADLB)
+```
+
+ADSL must be derived before ADRS. RANDDT and TRTSDT from ADSL are required for
+clinical benefit and study day derivation.
+
+## References
+
+- [admiralonco documentation](https://pharmaverse.github.io/admiralonco/)
+- [admiralonco ADRS vignette](https://pharmaverse.github.io/admiralonco/articles/adrs.html)
+- [CDISC ADaMIG v1.3](https://www.cdisc.org/standards/foundational/adam)
+- [RECIST 1.1 guidelines](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3107559/)
+- [pharmaverse examples — ADRS](https://pharmaverse.github.io/examples/)
+
+## Author
+
+Jeff Dickinson, Navitas Data Sciences

--- a/admiral/admiral-adrs/SKILL.md
+++ b/admiral/admiral-adrs/SKILL.md
@@ -1,0 +1,413 @@
+---
+name: admiral-adrs
+description: >
+  Derives an ADaM Tumor Response Analysis Dataset (ADRS) using the {admiral}
+  and {admiralonco} R packages. Use when a user needs to create ADRS from SDTM
+  RS domain data, derive RECIST 1.1 response parameters (overall response,
+  confirmed response, best overall response, clinical benefit), or generate
+  QC-ready R code following CDISC ADaM and oncology conventions. Requires SDTM
+  RS input data, ADSL with randomization and treatment dates, and an ADaM ADRS
+  specification.
+license: MIT
+metadata:
+  author: Navitas Data Sciences
+  version: "0.1"
+  pharmaverse: "true"
+  parent: admiral
+compatibility: >
+  Requires R with admiral, admiralonco, dplyr, lubridate, and pharmaversesdtm
+  installed. Requires a completed ADSL dataset with RANDDT and TRTSDT. Designed
+  for use in a GxP-compliant oncology trial environment with access to SDTM RS
+  domain data and an ADaM ADRS specification.
+---
+
+# admiral-adrs
+
+> Shared conventions (library setup, pipe style, date rules, flag convention,
+> `# REVIEW:` annotations, `stopifnot()` patterns) are defined in the parent
+> [`../SKILL.md`](../SKILL.md). The workflow below is ADRS-specific.
+
+Derives a CDISC-conformant ADRS tumor response dataset using {admiral} and
+{admiralonco}. Outputs executable, QC-ready R code covering RECIST 1.1 response
+parameters with full derivation traceability.
+
+The primary design challenge in ADRS is the **confirmation logic**: CR and PR
+must be supported by a second qualifying assessment ≥28 days later. Best Overall
+Response (BOR) follows a strict hierarchy (CR > PR > SD > NON-CR/NON-PD > PD >
+NE) and handles NE propagation in ways that manual `case_when()` or `slice_min()`
+cannot replicate correctly. Always use `admiralonco` functions — never manual
+derivations.
+
+---
+
+## Inputs
+
+Before generating code, confirm the following are available or explicitly noted
+as absent:
+
+| Input | Required | Notes |
+|---|---|---|
+| RS | Yes | One record per tumor assessment per subject; RSSTRESC contains the response category (CR/PR/SD/PD/NE) |
+| ADSL | Yes | Provides TRTSDT, RANDDT, treatment labels, population flags |
+| ADaM ADRS spec | Yes | Parameter list, PARAMCD/PARAM mapping, confirmation window, clinical benefit definition |
+| Study context | Yes | RECIST version (1.0 vs 1.1), assessor (investigator vs BICR), confirmation window, clinical benefit anchor date |
+
+If RS or ADSL are absent, stop and request them.
+
+**Note on pharmaversesdtm test data:** The `pharmaversesdtm` package no longer
+exports a plain `rs` object. Use `pharmaversesdtm::rs_onco_recist` for test or
+benchmark runs. When working with real study data, load RS from the study's
+SDTM package or file path.
+
+---
+
+## Workflow
+
+Follow these steps in order. Generate code section by section, not as a single
+block.
+
+### Step 1 — Setup and domain loading
+
+```r
+library(admiral)
+library(admiralonco)
+library(dplyr)
+library(lubridate)
+library(pharmaversesdtm)
+
+# Load RS domain
+# For pharmaversesdtm test data: use rs_onco_recist (plain `rs` no longer exported)
+rs   <- pharmaversesdtm::rs_onco_recist
+adsl <- adsl  # assumed derived upstream; replace with path/load as needed
+
+# Confirm RS has at least one record
+stopifnot(nrow(rs) > 0)
+```
+
+### Step 2 — DOMAIN removal
+
+Remove DOMAIN from RS **before** any `derive_param_*()` or `derive_vars_merged()`
+calls. admiral errors when DOMAIN exists in both the dataset and a source dataset
+passed to these functions.
+
+```r
+rs <- rs |> select(-DOMAIN)
+```
+
+### Step 3 — Merge ADSL backbone variables
+
+Bring required ADSL variables into the RS dataset before parameter derivation.
+At minimum: RANDDT and TRTSDT (clinical benefit anchor and study day reference),
+treatment labels, and population flags.
+
+```r
+# REVIEW: Confirm which ADSL variables are required by the ADaM ADRS spec.
+#   RANDDT is the conventional clinical benefit anchor date; TRTSDT is required
+#   for ADY derivation. Add or remove population flags per the spec.
+adrs <- rs |>
+  derive_vars_merged(
+    dataset_add = adsl,
+    by_vars     = exprs(STUDYID, USUBJID),
+    new_vars    = exprs(RANDDT, TRTSDT, TRT01P, TRT01PN, TRT01A, TRT01AN,
+                        ITTFL, SAFFL)
+  )
+```
+
+### Step 4 — Date derivation (ADT, ADTF, ADY)
+
+Derive the analysis date from RSDTC. This must happen **before** any
+`derive_param_*()` call — admiralonco response functions use ADT internally for
+confirmation window comparisons.
+
+```r
+adrs <- adrs |>
+  derive_vars_dt(
+    dtc             = RSDTC,
+    new_vars_prefix = "A",
+    date_imputation = "first",
+    flag_imputation = "auto"
+  ) |>
+  derive_vars_dy(
+    reference_date = TRTSDT,
+    source_vars    = exprs(ADT)
+  )
+```
+
+### Step 5 — Analysis value (AVALC, AVAL)
+
+Set AVALC from RSSTRESC and derive the numeric AVAL using the admiralonco helper
+`aval_resp()`. This function maps response categories to a monotone numeric scale:
+CR=1, PR=2, SD=3, NON-CR/NON-PD=4, PD=5, NE=6.
+
+```r
+# REVIEW: Confirm that RSSTRESC values in this study's RS domain align with the
+#   RECIST 1.1 CT expected by aval_resp(). Non-standard categories (e.g.
+#   "NON-CR/NON-PD" in lymphoma, iRECIST response categories) require a custom
+#   lookup if aval_resp() does not map them — do not suppress the resulting NA.
+adrs <- adrs |>
+  mutate(
+    AVALC = RSSTRESC,
+    AVAL  = aval_resp(AVALC)
+  )
+```
+
+### Step 6 — Overall response parameter (OVRLRESP)
+
+Add OVRLRESP records — one per subject per assessment timepoint. This parameter
+carries the verbatim response at each visit; it is not confirmation-adjusted.
+
+```r
+# REVIEW: PARAMCD and PARAM values must match the ADaM ADRS spec exactly.
+#   Adjust filter_source if the study uses a different assessor
+#   (BICR: RSEVAL == "INDEPENDENT ASSESSOR") or a different RECIST version.
+adrs <- adrs |>
+  derive_param_response(
+    dataset_adsl  = adsl,
+    filter_source = RSEVAL == "INVESTIGATOR" & RSEVALID == "RECIST 1.1",
+    source_var    = RSSTRESC,
+    set_values_to = exprs(
+      PARAMCD = "OVRLRESP",
+      PARAM   = "Overall Response by Investigator"
+    )
+  )
+```
+
+### Step 7 — Unconfirmed response flag (RSP)
+
+Add RSP records — one per subject, indicating whether any CR or PR was observed
+(unconfirmed). Retained alongside CONFIRMED to enable the ORR verification check
+in Step 11.
+
+```r
+adrs <- adrs |>
+  derive_param_response(
+    dataset_adsl  = adsl,
+    filter_source = RSEVAL == "INVESTIGATOR" & RSEVALID == "RECIST 1.1",
+    source_var    = RSSTRESC,
+    resp_val      = c("CR", "PR"),
+    set_values_to = exprs(
+      PARAMCD = "RSP",
+      PARAM   = "Response (Unconfirmed)"
+    )
+  )
+```
+
+### Step 8 — Confirmed response (CONFIRMED)
+
+A CR or PR is confirmed when a second qualifying assessment ≥ `ref_confirm` days
+after the first also shows CR or PR. CONFIRMED = "Y" if the subject has at least
+one confirmed CR or PR; "N" otherwise.
+
+**Flag convention note:** CONFIRMED uses `"Y"`/`"N"`, not `"Y"`/`NA` — this is
+the documented admiralonco contract. See
+[Flag convention exception](#flag-convention-exception-for-confirmed-and-cbrespfl)
+below. Do not recode `"N"` to `NA`.
+
+```r
+# REVIEW: ref_confirm = 28 is the RECIST 1.1 standard for CR/PR confirmation.
+#   Confirm this value against the study protocol and SAP — some programs specify
+#   21 days, and regulatory precedent exists for other windows. A wrong value
+#   silently inflates or deflates confirmed ORR.
+adrs <- adrs |>
+  derive_param_confirmed_resp(
+    dataset_adsl  = adsl,
+    filter_source = RSEVAL == "INVESTIGATOR" & RSEVALID == "RECIST 1.1",
+    source_var    = RSSTRESC,
+    ref_confirm   = 28,       # PLACEHOLDER — confirm from SAP
+    set_values_to = exprs(
+      PARAMCD = "CONFIRMED",
+      PARAM   = "Confirmed Response"
+    )
+  )
+```
+
+### Step 9 — Best overall response (BESTRESP)
+
+BOR applies the RECIST 1.1 hierarchy across all assessments for each subject.
+`derive_param_confirmed_bor()` handles confirmation requirements, the NE
+propagation rule, and the hierarchy correctly. Never substitute `slice_min(AVAL)`
+or manual `case_when()` — these cannot replicate the NE propagation logic.
+
+```r
+# REVIEW: missing_as_ne controls how missing assessments are treated in BOR.
+#   FALSE (default): missing assessments are ignored (excluded from BOR).
+#   TRUE: missing assessments count as NE, which can worsen BOR for subjects
+#   with gaps in the assessment schedule.
+#   Confirm the per-protocol analysis population definition with the
+#   statistical reviewer before committing to either value.
+adrs <- adrs |>
+  derive_param_confirmed_bor(
+    dataset_adsl  = adsl,
+    filter_source = RSEVAL == "INVESTIGATOR" & RSEVALID == "RECIST 1.1",
+    source_var    = RSSTRESC,
+    ref_confirm   = 28,       # must match Step 8
+    missing_as_ne = FALSE,    # PLACEHOLDER — confirm from SAP
+    set_values_to = exprs(
+      PARAMCD = "BESTRESP",
+      PARAM   = "Best Overall Response (Confirmed)"
+    )
+  )
+```
+
+### Step 10 — Clinical benefit (CBRESPFL)
+
+Clinical benefit is a durable non-progressive response: CR, PR, or SD sustained
+for ≥ `ref_start_window` days from `reference_date`. CBRESPFL = "Y" if criteria
+are met; "N" otherwise.
+
+**Flag convention note:** CBRESPFL uses `"Y"`/`"N"`, not `"Y"`/`NA`. Same
+admiralonco contract as CONFIRMED — do not recode.
+
+```r
+# REVIEW: Two protocol-specific decisions are required here and must both be
+#   confirmed from the protocol and SAP before use:
+#
+#   (1) reference_date — RANDDT is the conventional anchor. Some protocols
+#       instead define the 42-day window from the date of the first qualifying
+#       response (first SD, PR, or CR). If the protocol means "from first
+#       qualifying assessment", compute per-subject first-assessment dates
+#       and pass them as reference_date rather than a fixed ADSL variable.
+#
+#   (2) ref_start_window = 42 — RECIST standard for SD duration. Some studies
+#       use 35 or 56 days. Confirm from the protocol.
+adrs <- adrs |>
+  derive_param_clinbenefit(
+    dataset_adsl     = adsl,
+    filter_source    = RSEVAL == "INVESTIGATOR" & RSEVALID == "RECIST 1.1",
+    source_var       = RSSTRESC,
+    reference_date   = RANDDT,    # PLACEHOLDER — confirm anchor from protocol
+    ref_start_window = 42,        # PLACEHOLDER — confirm from protocol
+    set_values_to    = exprs(
+      PARAMCD = "CBRESPFL",
+      PARAM   = "Clinical Benefit"
+    )
+  )
+```
+
+### Step 11 — Verification: confirmed vs unconfirmed ORR
+
+Print response counts side-by-side and assert that confirmed ORR cannot exceed
+unconfirmed ORR. A confirmed count greater than unconfirmed count signals a
+configuration error in the confirmation window.
+
+```r
+# Print response parameter summary for QC — include in script output log
+response_summary <- adrs |>
+  filter(PARAMCD %in% c("RSP", "CONFIRMED", "CBRESPFL")) |>
+  count(PARAMCD, AVALC)
+print(response_summary)
+
+# Confirmed ORR must not exceed unconfirmed ORR
+n_confirmed   <- sum(adrs$PARAMCD == "CONFIRMED" & adrs$AVALC == "Y", na.rm = TRUE)
+n_unconfirmed <- sum(adrs$PARAMCD == "RSP"       & adrs$AVALC == "Y", na.rm = TRUE)
+stopifnot(n_confirmed <= n_unconfirmed)
+
+# PD is never a confirmed response
+stopifnot(!any(
+  adrs$PARAMCD == "CONFIRMED" & adrs$AVALC == "Y" &
+  adrs$AVAL == aval_resp("PD"),
+  na.rm = TRUE
+))
+```
+
+### Step 12 — Final checks
+
+```r
+# Required parameter coverage
+required_params <- c("OVRLRESP", "RSP", "CONFIRMED", "BESTRESP", "CBRESPFL")
+missing_params  <- setdiff(required_params, unique(adrs$PARAMCD))
+if (length(missing_params) > 0) {
+  stop("Missing required ADRS parameters: ", paste(missing_params, collapse = ", "))
+}
+
+# Uniqueness: one record per subject per subject-level parameter
+dup_check <- adrs |>
+  filter(PARAMCD %in% c("BESTRESP", "CONFIRMED", "RSP", "CBRESPFL")) |>
+  count(STUDYID, USUBJID, PARAMCD) |>
+  filter(n > 1)
+if (nrow(dup_check) > 0) {
+  stop("Duplicate subject-level parameter records found:\n",
+       paste(paste(dup_check$USUBJID, dup_check$PARAMCD), collapse = "\n"))
+}
+
+# Required variable presence check
+required_vars <- c(
+  "STUDYID", "USUBJID", "PARAMCD", "PARAM",
+  "ADT", "ADTF", "ADY", "AVAL", "AVALC", "TRTSDT"
+)
+missing_vars <- setdiff(required_vars, names(adrs))
+if (length(missing_vars) > 0) {
+  stop("Missing required ADRS variables: ", paste(missing_vars, collapse = ", "))
+}
+```
+
+---
+
+## Flag convention exception for CONFIRMED and CBRESPFL
+
+The admiral family convention is `"Y"` or `NA` — never `"N"` — for flag variables.
+ADRS has two named exceptions:
+
+| Variable | Values | Reason |
+|---|---|---|
+| `CONFIRMED` | `"Y"` / `"N"` | admiralonco contract: `"N"` means assessed but unconfirmed, not missing |
+| `CBRESPFL` | `"Y"` / `"N"` | admiralonco contract: same logic as CONFIRMED |
+
+**Do not recode `"N"` to `NA`** for these variables. The `"N"` records are
+required by downstream `derive_param_confirmed_bor()` logic to correctly
+identify subjects with no confirmed response. Recoding them breaks BOR
+derivation.
+
+All other flags in ADRS (ANL01FL, ABLFL, population flags from ADSL) follow the
+standard `"Y"` or `NA` convention.
+
+---
+
+## Common errors to avoid
+
+- **Using `rs` instead of `rs_onco_recist`** from pharmaversesdtm — the plain
+  `rs` object is no longer exported; the script will fail at load
+- **Using `case_when()` or `slice_min(AVAL)` for BOR** — manual BOR derivation
+  cannot replicate admiralonco's NE propagation rule and confirmation hierarchy;
+  always use `derive_param_confirmed_bor()`
+- **Not removing DOMAIN from RS** before `derive_param_*()` calls — causes
+  variable conflict errors; DOMAIN must be removed in Step 2, not in the final
+  `select()` at the end of the script
+- **Hardcoding `ref_confirm = 28`** without a `# REVIEW:` comment — the
+  confirmation window is protocol-specific and must come from the SAP; a wrong
+  value silently inflates or deflates confirmed ORR
+- **Applying `derive_vars_dt()` after `derive_param_response()`** — ADT must
+  exist before the response parameter functions run; the functions use ADT for
+  confirmation window comparisons
+- **Using RANDDT as the clinical benefit anchor without verifying protocol
+  intent** — if the protocol defines the 42-day window from the "first
+  qualifying response assessment" rather than randomization, a fixed RANDDT will
+  misclassify subjects
+- **Not printing the confirmed vs unconfirmed ORR comparison** — the omission
+  is a silent audit risk; confirmed ORR > unconfirmed ORR indicates a
+  derivation error that will not surface without an explicit check
+- **Recoding CONFIRMED or CBRESPFL `"N"` to `NA`** — these values are
+  meaningful per the admiralonco function contract; recoding breaks downstream
+  BOR derivation
+
+---
+
+## Output checklist
+
+Before returning code, verify:
+
+- [ ] DOMAIN removed from RS in Step 2, before any `derive_param_*()` call
+- [ ] ADSL merged with at minimum RANDDT, TRTSDT, and population flags before parameter derivation
+- [ ] ADT derived with `derive_vars_dt()` from RSDTC, with `flag_imputation = "auto"`
+- [ ] AVALC and AVAL (via `aval_resp()`) populated before `derive_param_response()` calls
+- [ ] All five parameters present in output: OVRLRESP, RSP, CONFIRMED, BESTRESP, CBRESPFL
+- [ ] `# REVIEW:` at PARAMCD/PARAM mapping in Steps 6–10
+- [ ] `# REVIEW:` at `ref_confirm` in Steps 8 and 9
+- [ ] `# REVIEW:` at `missing_as_ne` in Step 9
+- [ ] `# REVIEW:` at `reference_date` and `ref_start_window` in Step 10
+- [ ] Confirmed vs unconfirmed ORR comparison printed to console (Step 11)
+- [ ] `stopifnot(n_confirmed <= n_unconfirmed)` present (Step 11)
+- [ ] PD-never-confirmed assertion present (Step 11)
+- [ ] Required PARAMCD coverage check present (Step 12)
+- [ ] Uniqueness assertion for subject-level parameters (Step 12)
+- [ ] CONFIRMED and CBRESPFL values are `"Y"`/`"N"` — not recoded to `"Y"`/`NA`

--- a/admiral/admiral-adrs/benchmarks/README.md
+++ b/admiral/admiral-adrs/benchmarks/README.md
@@ -1,0 +1,43 @@
+# Benchmarks
+
+Each subdirectory contains one benchmark scenario for the `admiral-adrs` skill.
+
+## Structure
+
+Every benchmark follows this layout:
+
+```
+{benchmark-name}/
+├── prompt.md       # Natural language prompt given to the agent
+├── rubric.md       # Scoring criteria for evaluating agent output
+├── input/          # SDTM input datasets (R scripts to generate from pharmaversesdtm)
+└── expected/       # Expected output variables and values for correctness checks
+```
+
+## Planned Benchmarks
+
+| Benchmark | What it tests | Status |
+|---|---|---|
+| `recist-confirmed-bor` | Standard RECIST 1.1 BOR derivation using `rs_onco_recist`; CONFIRMED, BESTRESP, and ORR verification | Planned |
+| `clinical-benefit-anchor` | Clinical benefit derivation with RANDDT vs per-subject first-assessment anchor — tests whether agent flags the ambiguity with `# REVIEW:` | Planned |
+| `bicr-vs-investigator` | Dual-assessor scenario; tests whether agent derives separate PARAMCD sets for investigator and BICR assessments | Planned |
+| `ne-propagation` | Subject with all-NE assessment schedule; tests correct NE BOR and that CONFIRMED = "N" not NA | Planned |
+
+## Running a Benchmark Manually
+
+1. Give the agent the contents of `prompt.md` and `SKILL.md`
+2. Execute the generated R code against the input datasets in `input/`
+3. Score the output against `expected/` using the criteria in `rubric.md`
+
+## Existing GitHub Benchmark
+
+Issue [#167](https://github.com/RConsortium/pharma-skills/issues/167) was run
+against the `admiral-bds` skill before `admiral-adrs` existed. Re-running it
+against this skill will establish the baseline improvement delta.
+
+## Input Data
+
+Inputs are generated from
+[`{pharmaversesdtm}`](https://pharmaverse.github.io/pharmaversesdtm/) using
+`rs_onco_recist` (8 subjects, 66 records, RECIST 1.1). Edge case scenarios are
+applied within the `input/` scripts.


### PR DESCRIPTION
## Summary

- Adds `admiral/admiral-adrs/` — new child skill for ADRS derivation using `{admiral}` and `{admiralonco}`
- Updates `admiral/SKILL.md` routing table (adds admiral-adrs row, fixes admiral-adae from "planned" to active)
- Updates `CLAUDE.md` directory listing and trigger phrase table

## Motivation

`admiral-bds` was being routed to ADRS benchmark tasks but contains no ADRS-specific guidance. The #167 benchmark showed only a +2.3 pp skill advantage because agents had to discover the `admiralonco` API and RECIST QC requirements independently. All four `# REVIEW:` markers required by the rubric were missing from the skill-guided output.

## Key skill content

- 12-step workflow covering setup → DOMAIN removal → ADSL merge → date derivation → AVALC/AVAL → OVRLRESP → RSP → CONFIRMED → BESTRESP → CBRESPFL → ORR verification → final checks
- `# REVIEW:` at all four rubric decision points: `ref_confirm` (28 days), `missing_as_ne`, `reference_date` + `ref_start_window`, PARAMCD/PARAM mapping
- Documents the CONFIRMED/CBRESPFL `"Y"`/`"N"` exception to the admiral flag convention (and why recoding breaks BOR)
- Mandatory ORR verification printout + `stopifnot(confirmed_n <= unconfirmed_n)` in Step 11
- `rs_onco_recist` note (plain `rs` no longer exported from pharmaversesdtm)
- DESIGN.md with 5 design decisions and 3 open questions; benchmarks/README.md with 4 planned scenarios

## Test plan

- [ ] Rerun #167 benchmark with `admiral-adrs` as the skill — expect gap to widen from +2.3 pp to ≥+20 pp
- [ ] Verify skill routing: confirm `admiral/SKILL.md` and `CLAUDE.md` both point to `admiral/admiral-adrs`

Closes #197

🤖 Generated with [Claude Code](https://claude.ai/claude-code)