### PR TITLE
fix: correct raw_src convention in sdtm-oak skill

### DIFF
--- a/sdtm-oak/SKILL.md
+++ b/sdtm-oak/SKILL.md
@@ -92,11 +92,12 @@ all subsequent derivations. Call this once on the raw dataset.
 
 ```r
 # REVIEW: Set pat_var to the column holding the subject/patient identifier
-#   in this raw dataset. Set raw_src to a stable label for the CRF form.
+#   in this raw dataset. Set raw_src to the raw dataset object name (e.g. "ae_raw",
+#   "vs_raw") — pharmaverse convention uses the dataset name, not a CRF form label.
 ae_oak <- generate_oak_id_vars(
   raw_dat = ae_raw,
   pat_var = "patient_number",   # confirm column name from Step 1 inspection
-  raw_src = "AE_FORM"           # stable label for this raw source
+  raw_src = "ae_raw"            # pharmaverse convention: use the raw dataset name
 )
 # Adds: oak_id (row key), raw_source (form label), patient_number (subj ID)
 ```
@@ -350,7 +351,7 @@ stacking pattern — derive each TESTCD separately, then `bind_rows()`.
 
 # Parameter 1: Systolic Blood Pressure
 sysbp <- generate_oak_id_vars(vs_raw, pat_var = "patient_number",
-                               raw_src = "VS_FORM") |>
+                               raw_src = "vs_raw") |>
   hardcode_ct(tgt_var = "VSTESTCD", tgt_val = "SYSBP",
               raw_dat  = vs_raw, raw_var = "SYSBP_result",
               ct_spec  = ct_spec, ct_clst = "VSTESTCD") |>
@@ -363,7 +364,7 @@ sysbp <- generate_oak_id_vars(vs_raw, pat_var = "patient_number",
 
 # Parameter 2: Diastolic Blood Pressure — same pattern, different raw_var
 diabp <- generate_oak_id_vars(vs_raw, pat_var = "patient_number",
-                               raw_src = "VS_FORM") |>
+                               raw_src = "vs_raw") |>
   hardcode_ct(tgt_var = "VSTESTCD", tgt_val = "DIABP", ...) |>
   ...
 
@@ -397,7 +398,7 @@ decision that a QC reviewer must verify. Required locations:
 
 | Location | What to annotate |
 |---|---|
-| `generate_oak_id_vars()` | `pat_var` column name and `raw_src` label |
+| `generate_oak_id_vars()` | `pat_var` column name; `raw_src` must be the raw dataset name (e.g. `"ae_raw"`) |
 | Every `assign_datetime()` | `raw_fmt` format string — must match actual raw data |
 | Every `assign_ct()` | `ct_clst` codelist name — wrong codelist silently miscodes |
 | Every `condition_add()` | The business rule the condition implements |

--- a/sdtm-oak/references/oak-functions.md
+++ b/sdtm-oak/references/oak-functions.md
@@ -141,7 +141,8 @@ called first** before any mapping function.
 generate_oak_id_vars(
   raw_dat,
   pat_var,    # column in raw_dat holding subject identifier
-  raw_src     # string label for this CRF form / data source
+  raw_src     # raw dataset name — must equal the R object name (e.g. "ae_raw", "cm_raw")
+              # per sdtm.oak spec: "equal to the raw dataset (eCRF) name or eDT dataset name"
 )
 ```
 


### PR DESCRIPTION
## Summary

- `raw_src = "AE_FORM"` in `SKILL.md` Step 2 corrected to `"ae_raw"` — the sdtm.oak spec defines `raw_src` as the raw dataset object name, not a CRF form label
- Same fix applied to the Findings domain example (`"VS_FORM"` → `"vs_raw"`)
- `# REVIEW:` annotation comment and annotation rules table updated to state the convention explicitly
- `references/oak-functions.md` description corrected to match the official sdtm.oak spec

Fixes #201. Root cause identified from benchmark #159 run (2026-08-14): Assertion 1 scored Partial for Agent A, Pass for Agent B — the skill was the source of the regression.

## Test plan

- [ ] Rerun benchmark #159 — Assertion 1 should flip from Partial to Pass
- [ ] Verify no other `raw_src` examples in the skill use a descriptive label pattern

🤖 Generated with [Claude Code](https://claude.ai/claude-code)