### PR TITLE
eval: retarget #167 ADRS benchmark to admiral-adrs skill

### DIFF
--- a/_automation/evals/github-issue-167.json
+++ b/_automation/evals/github-issue-167.json
@@ -40,6 +40,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "admiral-bds"
+    "admiral-adrs"
   ]
 }


### PR DESCRIPTION
## Summary

- Updates `_automation/evals/github-issue-167.json` to set `target_skills: ["admiral-adrs"]` (was `["admiral-bds"]`)
- The admiral-adrs skill was created after the #167 eval was written; previous runs gave Agent A the generic BDS skill with no ADRS content, yielding only +2.3 pp improvement
- With the dedicated admiral-adrs skill, Agent A now receives RECIST 1.1 derivation patterns, confirmation logic, and CBRESPFL guidance

## Test plan

- [ ] Merge this PR
- [ ] Rerun benchmark #167 — expect a significant improvement over the +2.3 pp baseline
- [ ] Verify `target_skills` in JSON matches the `admiral-adrs` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)