### PR TITLE
eval: retarget #166 ADTTE benchmark to admiral-adtte skill

### DIFF
--- a/_automation/evals/github-issue-166.json
+++ b/_automation/evals/github-issue-166.json
@@ -34,6 +34,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "admiral-bds"
+    "admiral-adtte"
   ]
 }

--- a/_automation/evals/github-issue-167.json
+++ b/_automation/evals/github-issue-167.json
@@ -40,6 +40,6 @@
   ],
   "language": "R",
   "target_skills": [
-    "admiral-bds"
+    "admiral-adrs"
   ]
 }


### PR DESCRIPTION
## Summary

- Updates `_automation/evals/github-issue-166.json` to set `target_skills: ["admiral-adtte"]` (was `["admiral-bds"]`)
- Companion to PR #200 (admiral-adtte skill) and PR #203 (ADRS retargeting)
- The ADTTE eval covers `derive_param_tte()`, `event_source()`, `censor_source()`, and `compute_duration()` — none of which appear in the generic admiral-bds skill

## Test plan

- [ ] Merge PR #200 (admiral-adtte skill) first
- [ ] Merge this PR
- [ ] Run benchmark #166 — Agent A now receives the purpose-built ADTTE skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)